### PR TITLE
Add GitHub stars CTA to README and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@
 </p>
 
 <p align="center">
+  <b>⭐ If you find Vintrack useful, please consider giving it a star on GitHub! It helps the project grow and reach more people. ⭐</b>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/topic-vinted-blue?style=flat-square" alt="Vinted" />
+  <img src="https://img.shields.io/badge/topic-bot-blue?style=flat-square" alt="Bot" />
+  <img src="https://img.shields.io/badge/topic-scraper-blue?style=flat-square" alt="Scraper" />
+  <img src="https://img.shields.io/badge/topic-reselling-blue?style=flat-square" alt="Reselling" />
+  <img src="https://img.shields.io/badge/topic-monitor-blue?style=flat-square" alt="Monitor" />
+</p>
+
+<p align="center">
   <a href="#live-demo">Live Demo</a> •
   <a href="#getting-started">Getting Started</a> •
   <a href="#features">Features</a> •

--- a/apps/control-center/src/components/layout/header.tsx
+++ b/apps/control-center/src/components/layout/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Github, Star } from "lucide-react";
 
 export function Header() {
   const pathname = usePathname();
@@ -45,12 +45,25 @@ export function Header() {
         ))}
       </nav>
 
-      <div className="flex items-center gap-1.5 text-[11px] text-slate-400">
-        <span className="relative flex h-2 w-2">
-          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-          <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
-        </span>
-        Connected
+      <div className="flex items-center gap-4">
+        <a
+          href="https://github.com/jakob-kellermann/vintrack"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 text-[11px] font-medium text-slate-500 hover:text-amber-600 transition-colors bg-slate-50 hover:bg-amber-50 px-2 py-1 rounded-md border border-slate-200 hover:border-amber-200"
+        >
+          <Github className="w-3.5 h-3.5" />
+          Star us on GitHub
+          <Star className="w-3.5 h-3.5" />
+        </a>
+
+        <div className="flex items-center gap-1.5 text-[11px] text-slate-400">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+          </span>
+          Connected
+        </div>
       </div>
     </header>
   );

--- a/apps/control-center/src/components/layout/sidebar.tsx
+++ b/apps/control-center/src/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-import { LayoutDashboard, PlusCircle, Radio, LogOut, Globe, Shield, User } from "lucide-react";
+import { LayoutDashboard, PlusCircle, Radio, LogOut, Globe, Shield, User, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const ACCOUNT_SEEN_KEY = "vintrack:account-tab-seen";
@@ -105,6 +105,21 @@ export function Sidebar({ user }: SidebarProps) {
             <PlusCircle className="w-4 h-4 text-slate-400" />
             New Monitor
           </Link>
+        </div>
+
+        <div className="pt-4">
+          <p className="px-3 mb-2 text-[11px] font-medium text-slate-400 uppercase tracking-widest">
+            Community
+          </p>
+          <a
+            href="https://github.com/jakob-kellermann/vintrack"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-[13px] font-medium text-amber-600 hover:bg-amber-50 hover:text-amber-700 transition-colors"
+          >
+            <Star className="w-4 h-4" />
+            Star on GitHub
+          </a>
         </div>
 
         {user?.role === "admin" && (


### PR DESCRIPTION
Added prominent call-to-action sections in the README and GitHub Topic badges to improve visibility. Added "Star us on GitHub" links to the dashboard UI (sidebar and header) to encourage users to star the project.

---
*PR created automatically by Jules for task [17116788107999335374](https://jules.google.com/task/17116788107999335374) started by @JakobAIOdev*