### PR TITLE
🔒 Fix: Missing Input Sanitization for Monitor Webhook URL

### DIFF
--- a/apps/control-center/src/actions/dashboard-actions.ts
+++ b/apps/control-center/src/actions/dashboard-actions.ts
@@ -3,6 +3,7 @@
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { revalidatePath } from "next/cache";
+import { isValidDiscordWebhook } from "@/lib/validation";
 
 export async function stopAllMonitors() {
   const session = await auth();
@@ -37,6 +38,10 @@ export async function updateMonitorWebhook(monitorId: number, webhookUrl: string
     if (!session?.user) throw new Error("Unauthorized");
     
     const urlToSave = webhookUrl.trim() === "" ? null : webhookUrl.trim();
+
+    if (urlToSave && !isValidDiscordWebhook(urlToSave)) {
+        throw new Error("Invalid Discord Webhook URL");
+    }
 
     await db.monitors.update({
         where: { id: monitorId, userId: session.user.id },

--- a/apps/control-center/src/actions/monitor.ts
+++ b/apps/control-center/src/actions/monitor.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth"; 
+import { isValidDiscordWebhook } from "@/lib/validation";
 
 export async function createMonitor(formData: FormData) {
 
@@ -20,6 +21,7 @@ export async function createMonitor(formData: FormData) {
   const brandIds = (formData.get("brand_ids") as string) || null;
   const colorIds = (formData.get("color_ids") as string) || null;
   const region = (formData.get("region") as string) || "de";
+  const discordWebhook = (formData.get("discord_webhook") as string) || null;
   const proxyGroupRaw = formData.get("proxy_group_id") as string;
 
   if (!query) return;
@@ -54,6 +56,11 @@ export async function createMonitor(formData: FormData) {
     }
   }
 
+  const urlToSave = discordWebhook?.trim() || null;
+  if (urlToSave && !isValidDiscordWebhook(urlToSave)) {
+    throw new Error("Invalid Discord Webhook URL");
+  }
+
   await db.monitors.create({
     data: {
       userId: session.user.id,
@@ -65,8 +72,10 @@ export async function createMonitor(formData: FormData) {
       brand_ids: brandIds || null,
       color_ids: colorIds || null,
       region,
+      discord_webhook: urlToSave,
       proxy_group_id: proxyGroupId,
       status: "active",
+      webhook_active: urlToSave ? true : false,
     },
   });
 
@@ -119,6 +128,11 @@ export async function updateMonitor(id: number, formData: FormData) {
     proxyGroupId = null;
   }
 
+  const urlToSave = discordWebhook?.trim() || null;
+  if (urlToSave && !isValidDiscordWebhook(urlToSave)) {
+    throw new Error("Invalid Discord Webhook URL");
+  }
+
   await db.monitors.update({
     where: { id, userId: session.user.id },
     data: {
@@ -130,7 +144,7 @@ export async function updateMonitor(id: number, formData: FormData) {
       brand_ids: brandIds || null,
       color_ids: colorIds || null,
       region,
-      discord_webhook: discordWebhook?.trim() || null,
+      discord_webhook: urlToSave,
       proxy_group_id: proxyGroupId,
     },
   });

--- a/apps/control-center/src/lib/validation.ts
+++ b/apps/control-center/src/lib/validation.ts
@@ -1,0 +1,9 @@
+/**
+ * Validates if a string is a valid Discord webhook URL.
+ * Format: https://discord.com/api/webhooks/ID/TOKEN
+ */
+export function isValidDiscordWebhook(url: string): boolean {
+  const discordWebhookRegex =
+    /^https:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/webhooks\/\d{17,20}\/[A-Za-z0-9_-]+$/;
+  return discordWebhookRegex.test(url);
+}


### PR DESCRIPTION
### 🎯 What:
Fixed a security vulnerability where Discord Webhook URLs were saved to the database without proper sanitization or validation.

### ⚠️ Risk:
Leaving the webhook URL field unvalidated could allow an attacker to store malicious strings (e.g., `javascript:` URIs) or non-Discord URLs, potentially leading to cross-site scripting (XSS) if reflected in the UI or unintended data exfiltration if the backend attempts to use the invalid URL.

### 🛡️ Solution:
- Created a new validation utility `isValidDiscordWebhook` in `apps/control-center/src/lib/validation.ts` that uses a robust regular expression to verify the URL format.
- Integrated this validation into all relevant server actions: `updateMonitorWebhook`, `createMonitor`, and `updateMonitor`.
- Ensured that invalid URLs trigger a clear error message, preventing them from being persisted to the database.

---
*PR created automatically by Jules for task [8997096621181289685](https://jules.google.com/task/8997096621181289685) started by @JakobAIOdev*