### PR TITLE
⚡ Optimize GetAllSessions with Redis MGET

### DIFF
--- a/apps/vinted-service/internal/session/session.go
+++ b/apps/vinted-service/internal/session/session.go
@@ -89,14 +89,29 @@ func (m *Manager) GetAllSessions() ([]VintedSession, error) {
 	if err != nil {
 		return nil, err
 	}
-	var sessions []VintedSession
-	for _, key := range keys {
-		data, err := m.redis.Get(m.ctx, key).Bytes()
-		if err != nil {
+
+	if len(keys) == 0 {
+		return []VintedSession{}, nil
+	}
+
+	values, err := m.redis.MGet(m.ctx, keys...).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	sessions := make([]VintedSession, 0, len(values))
+	for _, val := range values {
+		if val == nil {
 			continue
 		}
+
+		s, ok := val.(string)
+		if !ok {
+			continue
+		}
+
 		var sess VintedSession
-		if err := json.Unmarshal(data, &sess); err != nil {
+		if err := json.Unmarshal([]byte(s), &sess); err != nil {
 			continue
 		}
 		sessions = append(sessions, sess)


### PR DESCRIPTION
The `GetAllSessions` function in `apps/vinted-service/internal/session/session.go` was previously fetching all session data by first getting all keys and then looping over them to perform individual `GET` requests. This is a classic N+1 query problem.

This PR optimizes the function by using the Redis `MGET` command to fetch all session data in a single batch.

### Performance Impact:
- **Network Roundtrips:** Reduced from O(N) to O(1) (specifically, from N+1 to 2).
- **Allocations:** Reduced by pre-allocating the results slice.

### Correctness:
- Handled the edge case where no keys exist (Redis `MGET` requires at least one key).
- Maintained existing error-handling behavior by continuing if individual session data is malformed or missing (though `MGET` results are now more consistent).
- Verified via manual code review; automated tests were attempted but blocked by environment restrictions (lack of internet for dependency downloads).

---
*PR created automatically by Jules for task [14720163659971111047](https://jules.google.com/task/14720163659971111047) started by @JakobAIOdev*