### PR TITLE
🧹 Replace leftover fmt.Printf debug prints with standard logging

### DIFF
--- a/apps/worker/internal/scraper/engine.go
+++ b/apps/worker/internal/scraper/engine.go
@@ -300,7 +300,9 @@ func (e *Engine) MonitorTask(ctx context.Context, m model.Monitor) {
 			}
 		}
 
-		fmt.Printf("\r[%d] #%d | %d items | %d new | %dms", m.ID, checks, len(items), len(newItems), time.Since(cycleStart).Milliseconds())
+		if len(newItems) > 0 {
+			log.Printf("[%d] #%d | %d items | %d new | %dms", m.ID, checks, len(items), len(newItems), time.Since(cycleStart).Milliseconds())
+		}
 
 		if len(newItems) == 0 {
 			if remaining := intervalDuration - time.Since(cycleStart); remaining > 0 {
@@ -327,10 +329,8 @@ func (e *Engine) MonitorTask(ctx context.Context, m model.Monitor) {
 		}
 
 		for _, item := range builtItems {
-			fmt.Printf("\n  NEW [%d]: %s (%s) [%s]", m.ID, item.Title, item.Price, item.Size)
+			log.Printf("[%d] NEW: %s (%s) [%s]", m.ID, item.Title, item.Price, item.Size)
 		}
-		fmt.Println()
-
 		go func(ctx context.Context, items []model.Item, vItems []model.VintedItem, monitorID int, webhook string, webhookActive bool, query string, ps string, scr *HTMLScraper, dom string) {
 			if e.enrichSeller && scr != nil {
 				sem := make(chan struct{}, 10)


### PR DESCRIPTION
🎯 **What:** Replaced the terminal-specific `fmt.Printf("\r...")` debug log with `log.Printf` and added a condition to only log when `newItems > 0`. Also replaced individual item `fmt.Printf` lines with `log.Printf` and removed unnecessary trailing `fmt.Println()`.
💡 **Why:** Debug prints using `fmt.Printf` and raw carriage returns (`\r`) create massive amounts of log spam and unreadable formats in production log streams (like Docker or systemd). Relying on the standard `log` package and only logging meaningful events (finding new items) dramatically improves maintainability and observability.
✅ **Verification:** Ran `go vet`, `go build`, and `go test ./...` in the `apps/worker` directory. No functionality was altered, and the app continues to compile and pass its CI checks seamlessly. The code review tool evaluated the change and marked it as `#Correct#`.
✨ **Result:** Clean, production-ready logs that accurately trace monitor activity using the correct `[%d]` convention without spamming stdout during idle cycles.

---
*PR created automatically by Jules for task [9160271335680926015](https://jules.google.com/task/9160271335680926015) started by @JakobAIOdev*