### PR TITLE
Bolt: [performance improvement] React.memo on ItemCard

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-03-24 - [React.memo for SSE list bottlenecks]
+**Learning:** Real-time lists receiving frequent SSE updates (like `LiveFeed`) cause React to re-render every item component on every update. As the list grows, this creates an O(N) rendering bottleneck causing significant CPU spikes and browser jank.
+**Action:** Always wrap individual list item components in `React.memo` when rendering live lists that receive real-time updates via SSE or WebSockets to ensure O(1) performance per update.

--- a/apps/control-center/src/components/monitors/item-card.tsx
+++ b/apps/control-center/src/components/monitors/item-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, memo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { ExternalLink, ImageOff, Heart, MessageCircle, Send, Loader2, XIcon, ChevronLeft, ChevronRight, Tag } from "lucide-react";
 import Link from "next/link";
@@ -42,7 +42,12 @@ interface ItemCardProps {
   showMonitor?: boolean;
 }
 
-export function ItemCard({ item, showMonitor = false }: ItemCardProps) {
+// Bolt Optimization: Wrap ItemCard in React.memo
+// Why: Live lists receiving real-time updates via SSE (like live-feed) cause
+// the entire list component to re-render. Without memo, React re-renders O(N)
+// child components for every single new item event, causing massive CPU spikes
+// and jank when the list grows large.
+export const ItemCard = memo(function ItemCard({ item, showMonitor = false }: ItemCardProps) {
   const { linked, likedIds, addLike, removeLike } = useVintedAccount();
   const liked = likedIds.has(Number(item.id));
   const [liking, setLiking] = useState(false);
@@ -644,7 +649,7 @@ export function ItemCard({ item, showMonitor = false }: ItemCardProps) {
       </Dialog>
     </div>
   );
-}
+});
 
 export function ItemCardSkeleton() {
   return (


### PR DESCRIPTION
💡 What: Wrapped the `ItemCard` component in `React.memo` inside `apps/control-center/src/components/monitors/item-card.tsx`.
🎯 Why: Live lists receiving real-time updates via SSE (like `LiveFeed`) cause the entire list component to re-render. Without `memo`, React re-renders O(N) child components for every single new item event, causing massive CPU spikes and jank when the list grows large.
📊 Impact: Expected to reduce re-renders to O(1) per update, saving significant CPU cycles and maintaining a smooth UI as the item list grows.
🔬 Measurement: Verify by observing React DevTools Profiler while the live feed is receiving items, or by noting the reduced CPU load and smoother scrolling in the browser.

---
*PR created automatically by Jules for task [10469076870601674929](https://jules.google.com/task/10469076870601674929) started by @JakobAIOdev*