### PR TITLE
Improve/account sessions

### DIFF
--- a/apps/control-center/package.json
+++ b/apps/control-center/package.json
@@ -1,6 +1,6 @@
 {
     "name": "control-center",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/apps/control-center/src/app/(dashboard)/account/client.tsx
+++ b/apps/control-center/src/app/(dashboard)/account/client.tsx
@@ -573,7 +573,7 @@ export function AccountClient({
                                 </p>
                                 <p className="text-muted-foreground mt-1 text-xs">
                                     Sign in to Vinted in this same browser. The
-                                    extension syncs only session tokens and the
+                                    extension syncs only the session token and the
                                     selected Vinted domain.
                                 </p>
                             </div>
@@ -714,11 +714,13 @@ export function AccountClient({
                                 </strong>
                             </span>
                             <span>
-                                Refresh token:{" "}
+                                Browser refresh:{" "}
                                 <strong className="text-foreground font-medium">
-                                    {status.has_refresh_token
-                                        ? "saved"
-                                        : "missing"}
+                                    {status.browser_linked
+                                        ? "not copied"
+                                        : status.has_refresh_token
+                                          ? "saved"
+                                          : "missing"}
                                 </strong>
                             </span>
                             <span>

--- a/apps/control-center/src/app/(dashboard)/oneclick-buy-test/client.tsx
+++ b/apps/control-center/src/app/(dashboard)/oneclick-buy-test/client.tsx
@@ -713,13 +713,10 @@ export function OneClickBuyTestClient() {
                                 {isInvalidAuthResult(result) && (
                                     <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-300">
                                         Vinted rejected the stored access token
-                                        before checkout. Relink the account with
-                                        fresh access_token_web and
-                                        refresh_token_web values from the
-                                        currently logged-in browser session, not
-                                        from the request sample files. The
-                                        experimental buy flow cannot recover if
-                                        no valid refresh token is stored.
+                                        before checkout. Sync the browser
+                                        extension again with the currently
+                                        logged-in browser session, not with
+                                        values from the request sample files.
                                     </div>
                                 )}
                                 {isPaymentURLMissingResult(result) && (

--- a/apps/vinted-service/internal/api/server.go
+++ b/apps/vinted-service/internal/api/server.go
@@ -279,6 +279,20 @@ func accessTokenExpiry(token string) (time.Time, bool) {
 	return time.Unix(int64(exp), 0), true
 }
 
+func serverSideTokenRefreshAllowed(sess *session.VintedSession) bool {
+	return sess != nil && !sess.BrowserLinked && strings.TrimSpace(sess.RefreshToken) != ""
+}
+
+func sessionForServerSideClient(sess *session.VintedSession) *session.VintedSession {
+	if sess == nil || !sess.BrowserLinked || strings.TrimSpace(sess.RefreshToken) == "" {
+		return sess
+	}
+
+	clientSession := *sess
+	clientSession.RefreshToken = ""
+	return &clientSession
+}
+
 func (s *Server) canonicalizeSessionDomain(sess *session.VintedSession) {
 	if sess == nil {
 		return
@@ -298,6 +312,9 @@ func (s *Server) canonicalizeSessionDomain(sess *session.VintedSession) {
 func (s *Server) refreshSessionWithLock(userID string, sess *session.VintedSession) (*session.VintedSession, *vinted.Client, error) {
 	if sess == nil {
 		return nil, nil, errors.New("no linked Vinted account")
+	}
+	if sess.BrowserLinked {
+		return nil, nil, errors.New("browser-linked sessions are refreshed by the browser extension")
 	}
 	if strings.TrimSpace(sess.RefreshToken) == "" {
 		sess.Status = "missing_refresh_token"
@@ -387,7 +404,7 @@ func accountInfoWithRefresh(client *vinted.Client) (*vinted.AccountInfo, error) 
 	}
 
 	sess := client.GetSession()
-	if sess == nil || strings.TrimSpace(sess.RefreshToken) == "" {
+	if !serverSideTokenRefreshAllowed(sess) {
 		return nil, err
 	}
 
@@ -421,7 +438,7 @@ func (s *Server) getSessionAndClient(r *http.Request, w http.ResponseWriter) (*s
 
 	s.canonicalizeSessionDomain(sess)
 
-	if sess.RefreshToken != "" && accessTokenExpiresWithin(sess.AccessToken, proactiveRefreshWindow) {
+	if serverSideTokenRefreshAllowed(sess) && accessTokenExpiresWithin(sess.AccessToken, proactiveRefreshWindow) {
 		refreshed, refreshedClient, err := s.refreshSessionWithLock(userID, sess)
 		if err != nil {
 			log.Printf("[session] proactive token refresh failed for user %s: %v", userID, err)
@@ -440,7 +457,7 @@ func (s *Server) getSessionAndClient(r *http.Request, w http.ResponseWriter) (*s
 		}
 	}
 
-	client, err := vinted.NewClient(sess)
+	client, err := vinted.NewClient(sessionForServerSideClient(sess))
 	if err != nil {
 		writeError(w, "failed to create Vinted client", 500)
 		return nil, nil, false
@@ -455,7 +472,7 @@ func (s *Server) getSessionAndClient(r *http.Request, w http.ResponseWriter) (*s
 	if sess.Status != "active" {
 		log.Printf("[session] session for user %s is %s, attempting recovery...", userID, sess.Status)
 
-		if sess.RefreshToken != "" {
+		if serverSideTokenRefreshAllowed(sess) {
 			log.Printf("[session] attempting token refresh for user %s...", userID)
 			updated, updatedClient, err := s.refreshSessionWithLock(userID, sess)
 			if err != nil {
@@ -1766,6 +1783,10 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 	}
 	if sess == nil {
 		writeError(w, "no linked Vinted account", 404)
+		return
+	}
+	if sess.BrowserLinked {
+		writeError(w, "browser-linked Vinted sessions are refreshed by the browser extension", 400)
 		return
 	}
 	if sess.RefreshToken == "" {

--- a/apps/vintrack-browser-sync-extension/README.md
+++ b/apps/vintrack-browser-sync-extension/README.md
@@ -48,9 +48,8 @@ For users, distribute the signed `vintrack-browser-sync-extension-firefox.xpi` f
 Only these values are synced to Vintrack:
 
 - `access_token_web`
-- `refresh_token_web`
 - current Vinted domain
 - browser user agent
 - Vintrack light/dark theme preference
 
-It does not send the full cookie jar.
+It does not send the full cookie jar or the browser refresh token.

--- a/apps/vintrack-browser-sync-extension/background.js
+++ b/apps/vintrack-browser-sync-extension/background.js
@@ -162,11 +162,92 @@ function ensurePeriodicSyncAlarm() {
   });
 }
 
+async function getOpenVintedTabs(preferredDomain = "") {
+  const normalizedPreferredDomain = sanitizeDomain(preferredDomain);
+  const tabs = await extensionApi.tabs.query({});
+  return tabs.filter((tab) => {
+    const domain = domainFromUrl(tab?.url || "");
+    if (!domain || !isVintedDomain(domain)) {
+      return false;
+    }
+    return (
+      !normalizedPreferredDomain ||
+      domain === normalizedPreferredDomain ||
+      cookieDomainMatches(domain, normalizedPreferredDomain)
+    );
+  });
+}
+
+async function refreshOpenVintedBrowserSessions(preferredDomain = "") {
+  const tabs = await getOpenVintedTabs(preferredDomain);
+  if (tabs.length === 0) {
+    return [
+      {
+        ok: false,
+        reason: "no-open-vinted-tab",
+        error: "Open a logged-in Vinted tab, then sync again.",
+      },
+    ];
+  }
+
+  const results = [];
+
+  for (const tab of tabs) {
+    if (typeof tab.id !== "number") {
+      continue;
+    }
+
+    try {
+      try {
+        await waitForTabBridge(tab.id, 5000);
+      } catch {
+        await extensionApi.tabs.reload(tab.id);
+        await waitForTabLoad(tab.id);
+        await waitForTabBridge(tab.id, 10000);
+      }
+      const result = await extensionApi.tabs.sendMessage(tab.id, {
+        type: "VINTRACK_REFRESH_BROWSER_SESSION",
+        payload: { requestId: crypto.randomUUID() },
+      });
+      results.push({
+        ok: Boolean(result?.ok),
+        domain: sanitizeDomain(result?.domain || domainFromUrl(tab.url || "")),
+        tabId: tab.id,
+        status: result?.status,
+        error: result?.error || "",
+      });
+    } catch (error) {
+      results.push({
+        ok: false,
+        domain: domainFromUrl(tab.url || ""),
+        tabId: tab.id,
+        error: error instanceof Error ? error.message : "unknown-error",
+      });
+    }
+  }
+
+  if (results.some((result) => result.ok)) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return results;
+}
+
 async function persistSyncState(results) {
+  const normalizedResults =
+    results.length > 0
+      ? results
+      : [
+          {
+            ok: false,
+            reason: "missing-browser-token",
+            error: "Open or reload a logged-in Vinted tab, then sync again.",
+          },
+        ];
   const successfulDomains = results
     .filter((result) => result.ok && result.domain && (!result.status || result.status === "completed" || result.status === "refreshed"))
     .map((result) => result.domain);
-  const failedResult = results.find((result) => !result.ok);
+  const failedResult = normalizedResults.find((result) => !result.ok);
 
   await extensionApi.storage.local.set({
     [STORAGE_KEYS.lastSyncAt]: new Date().toISOString(),
@@ -222,11 +303,8 @@ async function syncDomain(domain, options = {}) {
   const accessCookie = await extensionApi.cookies.get(
     cookieLookupDetails(normalizedDomain, "access_token_web", storeId)
   );
-  const refreshCookie = await extensionApi.cookies.get(
-    cookieLookupDetails(normalizedDomain, "refresh_token_web", storeId)
-  );
 
-  if (!accessCookie?.value && !refreshCookie?.value) {
+  if (!accessCookie?.value) {
     return { ok: false, reason: "missing-browser-token" };
   }
 
@@ -240,7 +318,6 @@ async function syncDomain(domain, options = {}) {
       body: JSON.stringify({
         link_token: browserLinkToken,
         access_token: accessCookie?.value || "",
-        refresh_token: refreshCookie?.value || "",
         domain: normalizedDomain,
         user_agent: navigator.userAgent,
       }),
@@ -265,10 +342,9 @@ async function syncDomain(domain, options = {}) {
 
 async function syncAllVintedDomains() {
   const accessCookies = await extensionApi.cookies.getAll({ name: "access_token_web" });
-  const refreshCookies = await extensionApi.cookies.getAll({ name: "refresh_token_web" });
   const candidates = new Map();
 
-  for (const cookie of [...accessCookies, ...refreshCookies]) {
+  for (const cookie of accessCookies) {
     const domain = sanitizeDomain(cookie.domain);
     if (!isVintedDomain(domain)) {
       continue;
@@ -301,13 +377,9 @@ async function syncPreferredOrAllDomains(preferredDomain) {
     const cookies = (await extensionApi.cookies.getAll({ name: "access_token_web" })).filter((cookie) =>
       cookieDomainMatches(cookie.domain, normalizedPreferredDomain)
     );
-    const refreshCookies = (await extensionApi.cookies.getAll({ name: "refresh_token_web" })).filter((cookie) =>
-      cookieDomainMatches(cookie.domain, normalizedPreferredDomain)
-    );
     const storeIds = [
       ...new Set(
-        [...cookies, ...refreshCookies]
-          .map((cookie) => (typeof cookie.storeId === "string" ? cookie.storeId : ""))
+        cookies.map((cookie) => (typeof cookie.storeId === "string" ? cookie.storeId : ""))
       ),
     ];
     const targets = storeIds.length > 0 ? storeIds : [""];
@@ -347,13 +419,47 @@ async function syncPreferredOrAllDomains(preferredDomain) {
 }
 
 async function syncAndPersistPreferredOrAllDomains(preferredDomain) {
-  const results = await syncPreferredOrAllDomains(preferredDomain);
+  let results = await syncPreferredOrAllDomains(preferredDomain);
+  if (!results.some((result) => result.ok)) {
+    const refreshResults = await refreshOpenVintedBrowserSessions(preferredDomain);
+    if (refreshResults.some((result) => result.ok)) {
+      results = await syncPreferredOrAllDomains(preferredDomain);
+      if (results.length === 0) {
+        results = [
+          {
+            ok: false,
+            reason: "missing-browser-token",
+            error: "Vinted did not expose a fresh browser access token after refresh.",
+          },
+        ];
+      }
+    } else if (results.length === 0) {
+      results = refreshResults;
+    }
+  }
   await persistSyncState(results);
   return results;
 }
 
 async function syncAndPersistAllDomains() {
-  const results = await syncAllVintedDomains();
+  let results = await syncAllVintedDomains();
+  if (!results.some((result) => result.ok)) {
+    const refreshResults = await refreshOpenVintedBrowserSessions();
+    if (refreshResults.some((result) => result.ok)) {
+      results = await syncAllVintedDomains();
+      if (results.length === 0) {
+        results = [
+          {
+            ok: false,
+            reason: "missing-browser-token",
+            error: "Vinted did not expose a fresh browser access token after refresh.",
+          },
+        ];
+      }
+    } else if (results.length === 0) {
+      results = refreshResults;
+    }
+  }
   await persistSyncState(results);
   return results;
 }
@@ -648,7 +754,7 @@ async function scheduleSyncForTab(tab) {
 }
 
 extensionApi.cookies.onChanged.addListener(({ cookie }) => {
-  if (!cookie || !["access_token_web", "refresh_token_web"].includes(cookie.name)) {
+  if (!cookie || cookie.name !== "access_token_web") {
     return;
   }
   scheduleSync(cookie.domain, { storeId: typeof cookie.storeId === "string" ? cookie.storeId : "" });
@@ -725,7 +831,16 @@ extensionApi.runtime.onMessage.addListener((message, sender, sendResponse) => {
       const preferredDomain = String(message?.payload?.preferredDomain || "").trim();
       const results = await syncAndPersistPreferredOrAllDomains(preferredDomain);
       const config = await getConfig();
-      sendResponse({ ok: true, ...formatRuntimeState(config), results });
+      const successful = results.some((result) => result.ok);
+      const failedResult = results.find((result) => !result.ok);
+      sendResponse({
+        ok: successful,
+        ...formatRuntimeState(config),
+        error: successful
+          ? ""
+          : failedResult?.error || failedResult?.reason || "Open a logged-in Vinted tab, then sync again.",
+        results,
+      });
       return;
     }
 

--- a/apps/vintrack-browser-sync-extension/content-script.js
+++ b/apps/vintrack-browser-sync-extension/content-script.js
@@ -150,6 +150,44 @@
     });
   }
 
+  function requestPageSessionRefresh(payload = {}) {
+    return new Promise((resolve) => {
+      const requestId = payload?.requestId || crypto.randomUUID();
+      const timeout = window.setTimeout(() => {
+        window.removeEventListener("message", handleResponse);
+        resolve({
+          ok: false,
+          code: "page_bridge_timeout",
+          error: "Vinted page bridge did not answer in time",
+          requestId,
+        });
+      }, 30000);
+
+      function handleResponse(event) {
+        if (
+          event.source !== window ||
+          event.data?.type !== "VINTRACK_PAGE_SESSION_REFRESH_RESPONSE" ||
+          event.data.payload?.requestId !== requestId
+        ) {
+          return;
+        }
+
+        window.clearTimeout(timeout);
+        window.removeEventListener("message", handleResponse);
+        resolve(event.data.payload);
+      }
+
+      window.addEventListener("message", handleResponse);
+      window.postMessage(
+        {
+          type: "VINTRACK_PAGE_SESSION_REFRESH_REQUEST",
+          payload: { ...payload, requestId },
+        },
+        window.location.origin
+      );
+    });
+  }
+
   ensurePageBridge();
   watchVintrackTheme();
 
@@ -225,6 +263,22 @@
       ensurePageBridge();
       waitForPageBridgeReady()
         .then(() => requestPageBuy(message.payload))
+        .then((response) => sendResponse(response))
+        .catch((error) =>
+          sendResponse({
+            ok: false,
+            code: "page_bridge_error",
+            error: error instanceof Error ? error.message : "Unknown page bridge error",
+            requestId: message.payload?.requestId,
+          })
+        );
+      return true;
+    }
+
+    if (message?.type === "VINTRACK_REFRESH_BROWSER_SESSION") {
+      ensurePageBridge();
+      waitForPageBridgeReady()
+        .then(() => requestPageSessionRefresh(message.payload))
         .then((response) => sendResponse(response))
         .catch((error) =>
           sendResponse({

--- a/apps/vintrack-browser-sync-extension/manifest.firefox.json
+++ b/apps/vintrack-browser-sync-extension/manifest.firefox.json
@@ -1,49 +1,49 @@
 {
-  "manifest_version": 3,
-  "name": "Vintrack Browser Sync",
-  "version": "0.1.0",
-  "description": "Keeps Vintrack Vinted tokens synced automatically.",
-  "permissions": ["alarms", "cookies", "storage", "tabs"],
-  "host_permissions": ["<all_urls>"],
-  "background": {
-    "scripts": ["background.js"]
-  },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "browser-sync@vintrack.app",
-      "strict_min_version": "109.0",
-      "data_collection_permissions": {
-        "required": ["authenticationInfo", "websiteActivity"]
-      }
+    "manifest_version": 3,
+    "name": "Vintrack Browser Sync",
+    "version": "0.1.1",
+    "description": "Keeps the Vintrack Vinted session synced automatically.",
+    "permissions": ["alarms", "cookies", "storage", "tabs"],
+    "host_permissions": ["<all_urls>"],
+    "background": {
+        "scripts": ["background.js"]
+    },
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "browser-sync@vintrack.app",
+            "strict_min_version": "109.0",
+            "data_collection_permissions": {
+                "required": ["authenticationInfo", "websiteActivity"]
+            }
+        }
+    },
+    "icons": {
+        "16": "icons/vintrack-16.png",
+        "32": "icons/vintrack-32.png",
+        "48": "icons/vintrack-48.png",
+        "128": "icons/vintrack-128.png"
+    },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content-script.js"],
+            "run_at": "document_start"
+        }
+    ],
+    "web_accessible_resources": [
+        {
+            "resources": ["page-bridge.js"],
+            "matches": ["<all_urls>"]
+        }
+    ],
+    "action": {
+        "default_title": "Vintrack Browser Sync",
+        "default_popup": "popup.html",
+        "default_icon": {
+            "16": "icons/vintrack-16.png",
+            "32": "icons/vintrack-32.png",
+            "48": "icons/vintrack-48.png",
+            "128": "icons/vintrack-128.png"
+        }
     }
-  },
-  "icons": {
-    "16": "icons/vintrack-16.png",
-    "32": "icons/vintrack-32.png",
-    "48": "icons/vintrack-48.png",
-    "128": "icons/vintrack-128.png"
-  },
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content-script.js"],
-      "run_at": "document_start"
-    }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": ["page-bridge.js"],
-      "matches": ["<all_urls>"]
-    }
-  ],
-  "action": {
-    "default_title": "Vintrack Browser Sync",
-    "default_popup": "popup.html",
-    "default_icon": {
-      "16": "icons/vintrack-16.png",
-      "32": "icons/vintrack-32.png",
-      "48": "icons/vintrack-48.png",
-      "128": "icons/vintrack-128.png"
-    }
-  }
 }

--- a/apps/vintrack-browser-sync-extension/manifest.json
+++ b/apps/vintrack-browser-sync-extension/manifest.json
@@ -1,40 +1,40 @@
 {
-  "manifest_version": 3,
-  "name": "Vintrack Browser Sync",
-  "version": "0.1.0",
-  "description": "Keeps Vintrack Vinted tokens synced automatically.",
-  "permissions": ["alarms", "cookies", "storage", "tabs"],
-  "host_permissions": ["<all_urls>"],
-  "background": {
-    "service_worker": "background.js"
-  },
-  "icons": {
-    "16": "icons/vintrack-16.png",
-    "32": "icons/vintrack-32.png",
-    "48": "icons/vintrack-48.png",
-    "128": "icons/vintrack-128.png"
-  },
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content-script.js"],
-      "run_at": "document_start"
+    "manifest_version": 3,
+    "name": "Vintrack Browser Sync",
+    "version": "0.1.1",
+    "description": "Keeps the Vintrack Vinted session synced automatically.",
+    "permissions": ["alarms", "cookies", "storage", "tabs"],
+    "host_permissions": ["<all_urls>"],
+    "background": {
+        "service_worker": "background.js"
+    },
+    "icons": {
+        "16": "icons/vintrack-16.png",
+        "32": "icons/vintrack-32.png",
+        "48": "icons/vintrack-48.png",
+        "128": "icons/vintrack-128.png"
+    },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content-script.js"],
+            "run_at": "document_start"
+        }
+    ],
+    "web_accessible_resources": [
+        {
+            "resources": ["page-bridge.js"],
+            "matches": ["<all_urls>"]
+        }
+    ],
+    "action": {
+        "default_title": "Vintrack Browser Sync",
+        "default_popup": "popup.html",
+        "default_icon": {
+            "16": "icons/vintrack-16.png",
+            "32": "icons/vintrack-32.png",
+            "48": "icons/vintrack-48.png",
+            "128": "icons/vintrack-128.png"
+        }
     }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": ["page-bridge.js"],
-      "matches": ["<all_urls>"]
-    }
-  ],
-  "action": {
-    "default_title": "Vintrack Browser Sync",
-    "default_popup": "popup.html",
-    "default_icon": {
-      "16": "icons/vintrack-16.png",
-      "32": "icons/vintrack-32.png",
-      "48": "icons/vintrack-48.png",
-      "128": "icons/vintrack-128.png"
-    }
-  }
 }

--- a/apps/vintrack-browser-sync-extension/page-bridge.js
+++ b/apps/vintrack-browser-sync-extension/page-bridge.js
@@ -127,6 +127,27 @@
     );
   }
 
+  async function refreshBrowserSession() {
+    const csrfToken = extractCsrfToken();
+    const response = await fetch(`${window.location.origin}/web/api/auth/refresh`, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Accept": "application/json, text/plain, */*",
+        ...(csrfToken ? { "X-Csrf-Token": csrfToken } : {}),
+      },
+    });
+
+    const body = await response.text().catch(() => "");
+    return {
+      ok: response.ok,
+      status: response.status,
+      domain: window.location.hostname,
+      hasAccessCookie: Boolean(readCookie("access_token_web")),
+      error: response.ok ? "" : truncate(body, 200),
+    };
+  }
+
   function waitForDocumentReady(timeoutMs = 15000) {
     return new Promise((resolve, reject) => {
       if (document.readyState === "complete") {
@@ -571,11 +592,40 @@
   }
 
   window.addEventListener("message", (event) => {
-    if (
-      event.source !== window ||
-      event.data?.type !== "VINTRACK_PAGE_BUY_REQUEST" ||
-      !event.data.payload?.requestId
-    ) {
+    if (event.source !== window || !event.data?.type) {
+      return;
+    }
+
+    if (event.data.type === "VINTRACK_PAGE_SESSION_REFRESH_REQUEST") {
+      const requestId = event.data.payload?.requestId || crypto.randomUUID();
+      refreshBrowserSession()
+        .then((result) => {
+          window.postMessage(
+            {
+              type: "VINTRACK_PAGE_SESSION_REFRESH_RESPONSE",
+              payload: { ...result, requestId },
+            },
+            window.location.origin
+          );
+        })
+        .catch((error) => {
+          window.postMessage(
+            {
+              type: "VINTRACK_PAGE_SESSION_REFRESH_RESPONSE",
+              payload: {
+                ok: false,
+                requestId,
+                code: "page_session_refresh_exception",
+                error: error instanceof Error ? error.message : "Unknown browser session refresh failure",
+              },
+            },
+            window.location.origin
+          );
+        });
+      return;
+    }
+
+    if (event.data.type !== "VINTRACK_PAGE_BUY_REQUEST" || !event.data.payload?.requestId) {
       return;
     }
 

--- a/apps/vintrack-browser-sync-extension/popup.html
+++ b/apps/vintrack-browser-sync-extension/popup.html
@@ -323,7 +323,7 @@
 
         <div class="badge-row">
           <div id="connection-badge" class="badge">Awaiting connect</div>
-          <div id="auto-badge" class="badge">Watching for tokens</div>
+          <div id="auto-badge" class="badge">Watching session</div>
         </div>
 
         <p class="copy">
@@ -350,8 +350,8 @@
         <button id="clear" class="secondary-button" type="button">Clear extension data</button>
 
         <div class="footer">
-          Only <strong>access_token_web</strong>, <strong>refresh_token_web</strong>, domain, and
-          your browser user agent are sent to Vintrack.
+          Only <strong>access_token_web</strong>, domain, and your browser user agent are sent to
+          Vintrack.
         </div>
       </section>
     </main>

--- a/apps/vintrack-browser-sync-extension/popup.js
+++ b/apps/vintrack-browser-sync-extension/popup.js
@@ -54,7 +54,7 @@ function renderState(response) {
     );
     setBadge(
         autoBadgeEl,
-        lastSyncStatus === "ok" ? "Auto-sync healthy" : "Watching for tokens",
+        lastSyncStatus === "ok" ? "Auto-sync healthy" : "Watching session",
         lastSyncStatus === "ok" ? "ok" : "muted",
     );
     domainCountEl.textContent = String(domains.length);
@@ -78,7 +78,7 @@ function renderState(response) {
                 : "Connected and waiting for an active Vinted session.",
         );
         hintEl.textContent =
-            "Only the current Vinted session tokens are synced.";
+            "Only the current Vinted session token is synced.";
         return;
     }
 


### PR DESCRIPTION
+Fix: browser-linked Vinted sessions no longer copy or rotate the browser refresh token
+Improve: session sync now refreshes through the active Vinted browser tab before syncing
+Improve: Chrome extension sync detection is more reliable after extension reloads
+Improve: sync popup now shows clear errors when no active Vinted session is found
+Improve: account page now reflects that browser refresh tokens are not copied to Vintrack