### PR TITLE
Raised Telegram HTTP timeout from 5s to 20s

### DIFF
--- a/apps/worker/internal/telegram/telegram.go
+++ b/apps/worker/internal/telegram/telegram.go
@@ -2,11 +2,14 @@ package telegram
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,8 +19,9 @@ import (
 	"vintrack-worker/internal/model"
 )
 
-var httpClient = &http.Client{Timeout: 5 * time.Second}
+var httpClient = &http.Client{Timeout: 20 * time.Second}
 var apiBaseURL = "https://api.telegram.org"
+var retryBackoff = 750 * time.Millisecond
 
 type retryResponse struct {
 	Parameters struct {
@@ -107,7 +111,15 @@ func send(method string, payload map[string]interface{}) error {
 func postWithRetry(endpoint string, body []byte) error {
 	retryAfter, err := post(endpoint, body)
 	if err != nil {
-		return err
+		if !isTransientPostError(err) {
+			return err
+		}
+
+		time.Sleep(retryBackoff)
+		retryAfter, err = post(endpoint, body)
+		if err != nil {
+			return err
+		}
 	}
 	if retryAfter == nil {
 		return nil
@@ -127,6 +139,15 @@ func postWithRetry(endpoint string, body []byte) error {
 		return fmt.Errorf("telegram API rate limited after retry")
 	}
 	return nil
+}
+
+func isTransientPostError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func post(endpoint string, body []byte) (*int, error) {

--- a/apps/worker/internal/telegram/telegram_test.go
+++ b/apps/worker/internal/telegram/telegram_test.go
@@ -21,18 +21,21 @@ func withTelegramServer(t *testing.T, handler http.HandlerFunc) {
 
 	oldBaseURL := apiBaseURL
 	oldClient := httpClient
+	oldRetryBackoff := retryBackoff
 	oldToken, hadToken := os.LookupEnv("TELEGRAM_BOT_TOKEN")
 	oldDashboardURL, hadDashboardURL := os.LookupEnv("DASHBOARD_URL")
 
 	apiBaseURL = server.URL
 	httpClient = server.Client()
 	httpClient.Timeout = 2 * time.Second
+	retryBackoff = 0
 	os.Setenv("TELEGRAM_BOT_TOKEN", "test-token")
 	os.Unsetenv("DASHBOARD_URL")
 
 	t.Cleanup(func() {
 		apiBaseURL = oldBaseURL
 		httpClient = oldClient
+		retryBackoff = oldRetryBackoff
 		if hadToken {
 			os.Setenv("TELEGRAM_BOT_TOKEN", oldToken)
 		} else {
@@ -111,6 +114,36 @@ func TestSendItemFallsBackToMessageWhenPhotoFails(t *testing.T) {
 
 	if len(calls) != 2 {
 		t.Fatalf("expected photo plus fallback message, got %v", calls)
+	}
+}
+
+func TestSendItemRetriesPhotoTimeout(t *testing.T) {
+	var calls int32
+	var paths []string
+	withTelegramServer(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/bottest-token/sendPhoto" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if atomic.AddInt32(&calls, 1) == 1 {
+			time.Sleep(50 * time.Millisecond)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	})
+	httpClient.Timeout = 10 * time.Millisecond
+
+	SendItem("-1001", model.Item{
+		MonitorID: 7,
+		Title:     "Item",
+		Price:     "12 EUR",
+		URL:       "https://example.test/item",
+		ImageURL:  "https://example.test/image.jpg",
+	}, "monitor", "server")
+
+	if calls != 2 {
+		t.Fatalf("expected timeout retry, got %d calls: %v", calls, paths)
 	}
 }
 


### PR DESCRIPTION
- Raised Telegram HTTP timeout from 5s to 20s
- Added one retry for transient timeout/deadline errors before falling back to text
- Added a regression test for photo timeout retry