### PR TITLE
Harden regional proxy pool recovery

### DIFF
--- a/apps/control-center/prisma/migrations/20260802210000_optimize_free_proxy_health_claims/migration.sql
+++ b/apps/control-center/prisma/migrations/20260802210000_optimize_free_proxy_health_claims/migration.sql
@@ -1,0 +1,55 @@
+CREATE INDEX IF NOT EXISTS "free_proxy_health_window_due_idx"
+    ON "free_proxy_health"(
+        "region",
+        "candidate_window_token",
+        "next_check_at",
+        "status"
+    );
+
+CREATE TABLE IF NOT EXISTS "free_proxy_source_health_stats" (
+    "region" VARCHAR(10) NOT NULL,
+    "source" VARCHAR(50) NOT NULL,
+    "protocol" VARCHAR(20) NOT NULL,
+    "checked_count" INTEGER NOT NULL DEFAULT 0,
+    "success_count" INTEGER NOT NULL DEFAULT 0,
+    "failure_count" INTEGER NOT NULL DEFAULT 0,
+    "last_checked_at" TIMESTAMP(6),
+    "last_success_at" TIMESTAMP(6),
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "free_proxy_source_health_stats_pkey"
+        PRIMARY KEY ("region", "source", "protocol")
+);
+
+CREATE INDEX IF NOT EXISTS "free_proxy_source_health_stats_region_yield_idx"
+    ON "free_proxy_source_health_stats"(
+        "region",
+        "success_count",
+        "checked_count"
+    );
+
+INSERT INTO "free_proxy_source_health_stats" (
+    "region",
+    "source",
+    "protocol",
+    "checked_count",
+    "success_count",
+    "failure_count",
+    "last_checked_at",
+    "last_success_at",
+    "updated_at"
+)
+SELECT
+    fph."region",
+    fp."source",
+    fp."protocol",
+    COUNT(*) FILTER (WHERE fph."last_checked_at" IS NOT NULL)::integer,
+    COALESCE(SUM(fph."success_count"), 0)::integer,
+    COALESCE(SUM(fph."failure_count"), 0)::integer,
+    MAX(fph."last_checked_at"),
+    MAX(fph."last_success_at"),
+    CURRENT_TIMESTAMP
+FROM "free_proxy_health" fph
+JOIN "free_proxies" fp ON fp."id" = fph."proxy_id"
+GROUP BY fph."region", fp."source", fp."protocol"
+ON CONFLICT ("region", "source", "protocol") DO NOTHING;

--- a/apps/control-center/prisma/schema.prisma
+++ b/apps/control-center/prisma/schema.prisma
@@ -192,7 +192,24 @@ model free_proxy_health {
   @@index([region, last_checked_at])
   @@index([region, last_success_at])
   @@index([region, candidate_window_token], map: "free_proxy_health_region_candidate_window_idx")
+  @@index([region, candidate_window_token, next_check_at, status], map: "free_proxy_health_window_due_idx")
   @@index([status, score])
+}
+
+model free_proxy_source_health_stats {
+  region          String    @db.VarChar(10)
+  source          String    @db.VarChar(50)
+  protocol        String    @db.VarChar(20)
+  checked_count   Int       @default(0)
+  success_count   Int       @default(0)
+  failure_count   Int       @default(0)
+  last_checked_at DateTime? @db.Timestamp(6)
+  last_success_at DateTime? @db.Timestamp(6)
+  created_at      DateTime  @default(now()) @db.Timestamp(6)
+  updated_at      DateTime  @updatedAt @db.Timestamp(6)
+
+  @@id([region, source, protocol])
+  @@index([region, success_count, checked_count], map: "free_proxy_source_health_stats_region_yield_idx")
 }
 
 model monitor_runs {

--- a/apps/control-center/src/actions/admin.ts
+++ b/apps/control-center/src/actions/admin.ts
@@ -34,8 +34,7 @@ const FREE_PROXY_ACTIVE_CANDIDATE_LIMIT_KEY =
 const FREE_PROXY_IDLE_CANDIDATE_LIMIT_KEY =
     "free_proxy_candidate_limit_idle_region";
 const FREE_PROXY_READY_TARGET_KEY = "free_proxy_ready_target_active_region";
-const FREE_PROXY_RESERVE_TARGET_KEY =
-    "free_proxy_reserve_target_active_region";
+const FREE_PROXY_RESERVE_TARGET_KEY = "free_proxy_reserve_target_active_region";
 const FREE_PROXY_IDLE_TARGET_KEY = "free_proxy_idle_region_target";
 const FREE_PROXY_EMERGENCY_RECOVERY_KEY =
     "free_proxy_emergency_recovery_enabled";
@@ -173,6 +172,8 @@ type FreeProxyRegionRow = {
     promoted_last_hour: bigint;
     minutes_since_last_success: number | null;
     active_monitor_count: bigint;
+    due_now_count: bigint;
+    never_checked_count: bigint;
 };
 
 type FreeProxySourceDiagnosticRow = {
@@ -189,6 +190,49 @@ type FreeProxySourceDiagnosticRow = {
     top_error_code: string | null;
     top_error_stage: string | null;
 };
+
+type FreeProxyMaintainerRuntime = {
+    status: string;
+    heartbeatAt: string;
+    startedAt: string;
+    concurrency: number;
+    perRegionConcurrency: number;
+    batchPerRegion: number;
+    bootstrapBatchPerRegion: number;
+    checked: number;
+    passed: number;
+    failed: number;
+    canceled: number;
+    durationMs: number;
+};
+
+function parseFreeProxyMaintainerRuntime(
+    value: string | undefined,
+): FreeProxyMaintainerRuntime | null {
+    if (!value) return null;
+    try {
+        const parsed = JSON.parse(value) as Partial<FreeProxyMaintainerRuntime>;
+        if (!parsed.heartbeatAt || !parsed.status) return null;
+        return {
+            status: parsed.status,
+            heartbeatAt: parsed.heartbeatAt,
+            startedAt: parsed.startedAt ?? parsed.heartbeatAt,
+            concurrency: Number(parsed.concurrency ?? 0),
+            perRegionConcurrency: Number(parsed.perRegionConcurrency ?? 0),
+            batchPerRegion: Number(parsed.batchPerRegion ?? 0),
+            bootstrapBatchPerRegion: Number(
+                parsed.bootstrapBatchPerRegion ?? 0,
+            ),
+            checked: Number(parsed.checked ?? 0),
+            passed: Number(parsed.passed ?? 0),
+            failed: Number(parsed.failed ?? 0),
+            canceled: Number(parsed.canceled ?? 0),
+            durationMs: Number(parsed.durationMs ?? 0),
+        };
+    } catch {
+        return null;
+    }
+}
 
 type ParsedProxy = {
     proxyUrl: string;
@@ -1036,20 +1080,26 @@ export async function getFreeProxyAdminState() {
         settings,
         counts,
         regionRows,
-        sourceRows,
         recent,
         degradationSetting,
-    ] =
-        await Promise.all([
-            getFreeProxySettings(),
-            db.$queryRaw<FreeProxyStatusCountRow[]>`
+        runtimeSetting,
+    ] = await Promise.all([
+        getFreeProxySettings(),
+        db.$queryRaw<FreeProxyStatusCountRow[]>`
             SELECT status, COUNT(*)::bigint AS proxy_count
             FROM free_proxies
             GROUP BY status
         `,
-            db.$queryRaw<FreeProxyRegionRow[]>`
+        db.$queryRaw<FreeProxyRegionRow[]>`
+            WITH region_demand AS (
+                SELECT region, COUNT(*)::bigint AS active_monitor_count
+                FROM monitors
+                WHERE status = 'active'
+                  AND proxy_source = 'free'
+                GROUP BY region
+            )
             SELECT
-                region,
+                fph.region,
                 COUNT(*) FILTER (
                     WHERE (
                         status = 'active'
@@ -1110,12 +1160,12 @@ export async function getFreeProxyAdminState() {
                 )::bigint AS cooldown_count,
                 COUNT(*) FILTER (WHERE status = 'dead')::bigint AS dead_count,
                 COUNT(*) FILTER (
-                    WHERE last_checked_at >= NOW() - INTERVAL '24 hours'
+                    WHERE last_checked_at >= NOW() - INTERVAL '1 hour'
                       AND last_status_code = 200
                       AND last_error IS NULL
                 )::bigint AS recent_success_count,
                 COUNT(*) FILTER (
-                    WHERE last_checked_at >= NOW() - INTERVAL '24 hours'
+                    WHERE last_checked_at >= NOW() - INTERVAL '1 hour'
                 )::bigint AS recent_check_count,
                 percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)
                     FILTER (
@@ -1139,7 +1189,7 @@ export async function getFreeProxyAdminState() {
                 mode() WITHIN GROUP (ORDER BY last_error_stage)
                     FILTER (
                         WHERE last_error_stage IS NOT NULL
-                          AND last_checked_at >= NOW() - INTERVAL '24 hours'
+                          AND last_checked_at >= NOW() - INTERVAL '1 hour'
                     ) AS top_error_stage,
                 COUNT(*)::bigint AS candidate_window,
                 COUNT(*) FILTER (
@@ -1150,119 +1200,48 @@ export async function getFreeProxyAdminState() {
                 )::bigint AS promoted_last_hour,
                 EXTRACT(EPOCH FROM (NOW() - MAX(last_success_at))) / 60.0
                     AS minutes_since_last_success,
-                COALESCE(MAX(region_demand.active_monitor_count), 0)::bigint
-                    AS active_monitor_count
-            FROM free_proxy_health
-            LEFT JOIN LATERAL (
-                SELECT COUNT(*)::bigint AS active_monitor_count
-                FROM monitors monitor
-                WHERE monitor.status = 'active'
-                  AND monitor.proxy_source = 'free'
-                  AND monitor.region = free_proxy_health.region
-            ) region_demand ON TRUE
-            WHERE candidate_window_token =
-                FLOOR(EXTRACT(EPOCH FROM NOW()) / 3600)::bigint
-            GROUP BY region
-            ORDER BY region
-        `,
-            db.$queryRaw<FreeProxySourceDiagnosticRow[]>`
-            SELECT
-                fph.region,
-                listed_source.source_name AS source,
-                fp.protocol,
-                COUNT(DISTINCT fp.id)::bigint AS proxy_count,
+                COALESCE(region_demand.active_monitor_count, 0)::bigint
+                    AS active_monitor_count,
                 COUNT(*) FILTER (
-                    WHERE fph.last_checked_at >= NOW() - INTERVAL '24 hours'
-                )::bigint AS checked_count,
+                    WHERE next_check_at IS NULL OR next_check_at <= NOW()
+                )::bigint AS due_now_count,
                 COUNT(*) FILTER (
-                    WHERE fph.last_checked_at >= NOW() - INTERVAL '24 hours'
-                      AND fph.last_status_code = 200
-                      AND fph.last_error IS NULL
-                )::bigint AS successful_count,
-                COUNT(*) FILTER (
-                    WHERE fph.last_checked_at IS NULL
-                )::bigint AS never_checked_count,
-                COUNT(*) FILTER (
-                    WHERE (
-                        fph.status = 'active'
-                        OR (
-                            fph.status = 'cooldown'
-                            AND fph.success_count > 0
-                            AND fph.failure_streak <= 2
-                        )
-                      )
-                      AND fph.last_success_at >= NOW() - INTERVAL '20 minutes'
-                )::bigint AS active_count,
-                COUNT(*) FILTER (
-                    WHERE (
-                        fph.status = 'active'
-                        OR (
-                            fph.status = 'cooldown'
-                            AND fph.success_count > 0
-                        )
-                      )
-                      AND fph.failure_streak <= 2
-                      AND fph.last_success_at >= NOW() - INTERVAL '90 minutes'
-                      AND fph.last_success_at < NOW() - INTERVAL '20 minutes'
-                )::bigint AS reserve_count,
-                COUNT(*) FILTER (
-                    WHERE fph.status = 'dead'
-                       OR (
-                            fph.status = 'cooldown'
-                            AND (
-                                fph.success_count = 0
-                                OR fph.failure_streak > 2
-                                OR fph.last_success_at IS NULL
-                                OR fph.last_success_at < NOW() - INTERVAL '90 minutes'
-                            )
-                       )
-                )::bigint AS cooldown_count,
-                mode() WITHIN GROUP (ORDER BY fph.last_error_code)
-                    FILTER (
-                        WHERE fph.last_error_code IS NOT NULL
-                          AND fph.last_checked_at >= NOW() - INTERVAL '24 hours'
-                    ) AS top_error_code,
-                mode() WITHIN GROUP (ORDER BY fph.last_error_stage)
-                    FILTER (
-                        WHERE fph.last_error_stage IS NOT NULL
-                          AND fph.last_checked_at >= NOW() - INTERVAL '24 hours'
-                    ) AS top_error_stage
-            FROM free_proxies fp
-            CROSS JOIN LATERAL unnest(
-                CASE
-                    WHEN cardinality(fp.sources) > 0 THEN fp.sources
-                    ELSE ARRAY[fp.source]::text[]
-                END
-            ) AS listed_source(source_name)
-            JOIN free_proxy_health fph ON fph.proxy_id = fp.id
+                    WHERE last_checked_at IS NULL
+                )::bigint AS never_checked_count
+            FROM free_proxy_health fph
+            LEFT JOIN region_demand ON region_demand.region = fph.region
             WHERE fph.candidate_window_token =
                 FLOOR(EXTRACT(EPOCH FROM NOW()) / 3600)::bigint
-            GROUP BY fph.region, listed_source.source_name, fp.protocol
-            ORDER BY fph.region, successful_count DESC, checked_count DESC, listed_source.source_name, fp.protocol
+            GROUP BY fph.region, region_demand.active_monitor_count
+            ORDER BY fph.region
         `,
-            db.free_proxies.findMany({
-                orderBy: [{ updated_at: "desc" }],
-                take: 20,
-                select: {
-                    id: true,
-                    proxy_url: true,
-                    protocol: true,
-                    source: true,
-                    status: true,
-                    success_count: true,
-                    failure_count: true,
-                    last_checked_at: true,
-                    last_success_at: true,
-                    last_failure_at: true,
-                    quarantined_until: true,
-                    last_error: true,
-                },
-            }),
-            db.app_settings.findUnique({
-                where: { key: "free_proxy_degradation_reason" },
-                select: { value: true },
-            }),
-        ]);
+        db.free_proxies.findMany({
+            orderBy: [{ updated_at: "desc" }],
+            take: 20,
+            select: {
+                id: true,
+                proxy_url: true,
+                protocol: true,
+                source: true,
+                status: true,
+                success_count: true,
+                failure_count: true,
+                last_checked_at: true,
+                last_success_at: true,
+                last_failure_at: true,
+                quarantined_until: true,
+                last_error: true,
+            },
+        }),
+        db.app_settings.findUnique({
+            where: { key: "free_proxy_degradation_reason" },
+            select: { value: true },
+        }),
+        db.app_settings.findUnique({
+            where: { key: "free_proxy_maintainer_runtime" },
+            select: { value: true },
+        }),
+    ]);
 
     const countsByStatus = Object.fromEntries(
         counts.map((row) => [row.status, Number(row.proxy_count)]),
@@ -1287,6 +1266,9 @@ export async function getFreeProxyAdminState() {
             degradationSetting?.value === "host_egress_limited"
                 ? ("host_egress_limited" as const)
                 : null,
+        maintainerRuntime: parseFreeProxyMaintainerRuntime(
+            runtimeSetting?.value,
+        ),
         counts: {
             active: activeHealthCount,
             pending: pendingHealthCount || (countsByStatus.pending ?? 0),
@@ -1301,6 +1283,10 @@ export async function getFreeProxyAdminState() {
         regions: regionRows.map((row) => {
             const recentSuccessCount = Number(row.recent_success_count);
             const recentCheckCount = Number(row.recent_check_count);
+            const usableCount =
+                Number(row.active_count) +
+                Number(row.reserve_count) +
+                Number(row.warming_count);
 
             return {
                 region: row.region,
@@ -1334,7 +1320,9 @@ export async function getFreeProxyAdminState() {
                 recoveryMode:
                     settings.emergencyRecoveryEnabled &&
                     Number(row.active_monitor_count) > 0 &&
-                    Number(row.active_count) < settings.readyTarget,
+                    usableCount < settings.readyTarget,
+                dueNow: Number(row.due_now_count),
+                neverChecked: Number(row.never_checked_count),
                 healthy:
                     Number(row.active_count) +
                         Number(row.reserve_count) +
@@ -1342,30 +1330,119 @@ export async function getFreeProxyAdminState() {
                     settings.minActivePerRegion,
             };
         }),
-        sourceDiagnostics: sourceRows.map((row) => {
-            const checked = Number(row.checked_count);
-            const successful = Number(row.successful_count);
-            return {
-                region: row.region,
-                source: row.source,
-                protocol: row.protocol,
-                proxyCount: Number(row.proxy_count),
-                checked,
-                successful,
-                successRate:
-                    checked > 0
-                        ? Math.round((successful / checked) * 1000) / 10
-                        : null,
-                neverChecked: Number(row.never_checked_count),
-                active: Number(row.active_count),
-                reserve: Number(row.reserve_count),
-                cooldown: Number(row.cooldown_count),
-                topErrorCode: row.top_error_code,
-                topErrorStage: row.top_error_stage,
-            };
-        }),
+        sourceDiagnostics: [],
         recent,
     };
+}
+
+export async function getFreeProxySourceDiagnostics(region: string) {
+    await requireAdmin();
+    const normalizedRegion = region.trim().toLowerCase();
+    if (!/^[a-z]{2}$/.test(normalizedRegion)) {
+        return [];
+    }
+
+    const rows = await db.$queryRaw<FreeProxySourceDiagnosticRow[]>`
+        SELECT
+            fph.region,
+            listed_source.source_name AS source,
+            fp.protocol,
+            COUNT(DISTINCT fp.id)::bigint AS proxy_count,
+            COUNT(*) FILTER (
+                WHERE fph.last_checked_at >= NOW() - INTERVAL '1 hour'
+            )::bigint AS checked_count,
+            COUNT(*) FILTER (
+                WHERE fph.last_checked_at >= NOW() - INTERVAL '1 hour'
+                  AND fph.last_status_code = 200
+                  AND fph.last_error IS NULL
+            )::bigint AS successful_count,
+            COUNT(*) FILTER (
+                WHERE fph.last_checked_at IS NULL
+            )::bigint AS never_checked_count,
+            COUNT(*) FILTER (
+                WHERE (
+                    fph.status = 'active'
+                    OR (
+                        fph.status = 'cooldown'
+                        AND fph.success_count > 0
+                        AND fph.failure_streak <= 2
+                    )
+                  )
+                  AND fph.last_success_at >= NOW() - INTERVAL '20 minutes'
+            )::bigint AS active_count,
+            COUNT(*) FILTER (
+                WHERE (
+                    fph.status = 'active'
+                    OR (
+                        fph.status = 'cooldown'
+                        AND fph.success_count > 0
+                    )
+                  )
+                  AND fph.failure_streak <= 2
+                  AND fph.last_success_at >= NOW() - INTERVAL '90 minutes'
+                  AND fph.last_success_at < NOW() - INTERVAL '20 minutes'
+            )::bigint AS reserve_count,
+            COUNT(*) FILTER (
+                WHERE fph.status = 'dead'
+                   OR (
+                        fph.status = 'cooldown'
+                        AND (
+                            fph.success_count = 0
+                            OR fph.failure_streak > 2
+                            OR fph.last_success_at IS NULL
+                            OR fph.last_success_at < NOW() - INTERVAL '90 minutes'
+                        )
+                   )
+            )::bigint AS cooldown_count,
+            mode() WITHIN GROUP (ORDER BY fph.last_error_code)
+                FILTER (
+                    WHERE fph.last_error_code IS NOT NULL
+                      AND fph.last_checked_at >= NOW() - INTERVAL '1 hour'
+                ) AS top_error_code,
+            mode() WITHIN GROUP (ORDER BY fph.last_error_stage)
+                FILTER (
+                    WHERE fph.last_error_stage IS NOT NULL
+                      AND fph.last_checked_at >= NOW() - INTERVAL '1 hour'
+                ) AS top_error_stage
+        FROM free_proxies fp
+        CROSS JOIN LATERAL unnest(
+            CASE
+                WHEN cardinality(fp.sources) > 0 THEN fp.sources
+                ELSE ARRAY[fp.source]::text[]
+            END
+        ) AS listed_source(source_name)
+        JOIN free_proxy_health fph ON fph.proxy_id = fp.id
+        WHERE fph.region = ${normalizedRegion}
+          AND fph.candidate_window_token =
+            FLOOR(EXTRACT(EPOCH FROM NOW()) / 3600)::bigint
+        GROUP BY fph.region, listed_source.source_name, fp.protocol
+        ORDER BY successful_count DESC, checked_count DESC,
+            listed_source.source_name, fp.protocol
+        LIMIT 12
+    `;
+
+    return rows.map((row) => {
+        const checked = Number(row.checked_count);
+        const successful = Number(row.successful_count);
+        return {
+            region: row.region,
+            source: row.source,
+            protocol: row.protocol,
+            proxyCount: Number(row.proxy_count),
+            checked,
+            successful,
+            successRate:
+                checked > 0
+                    ? Math.round((successful / checked) * 1000) / 10
+                    : null,
+            neverChecked: Number(row.never_checked_count),
+            active: Number(row.active_count),
+            reserve: Number(row.reserve_count),
+            cooldown: Number(row.cooldown_count),
+            topErrorCode: row.top_error_code,
+            topErrorStage: row.top_error_stage,
+        };
+    });
 }
 
 export async function updateFreeProxySettings(formData: FormData) {

--- a/apps/control-center/src/app/(dashboard)/admin/client.tsx
+++ b/apps/control-center/src/app/(dashboard)/admin/client.tsx
@@ -63,6 +63,7 @@ import {
     getAdminUsersState,
     getAdminLogs,
     getFreeProxyAdminState,
+    getFreeProxySourceDiagnostics,
     getAdminUserDetails,
     addFreeProxies,
     clearFreeProxyQuarantine,
@@ -199,6 +200,20 @@ type FreeProxyRow = {
 
 type FreeProxyState = {
     degradationReason: "host_egress_limited" | null;
+    maintainerRuntime: {
+        status: string;
+        heartbeatAt: string;
+        startedAt: string;
+        concurrency: number;
+        perRegionConcurrency: number;
+        batchPerRegion: number;
+        bootstrapBatchPerRegion: number;
+        checked: number;
+        passed: number;
+        failed: number;
+        canceled: number;
+        durationMs: number;
+    } | null;
     settings: {
         enabled: boolean;
         autoImportEnabled: boolean;
@@ -246,6 +261,8 @@ type FreeProxyState = {
         minutesSinceLastSuccess: number | null;
         activeMonitorCount: number;
         recoveryMode: boolean;
+        dueNow: number;
+        neverChecked: number;
     }[];
     sourceDiagnostics: {
         region: string;
@@ -278,7 +295,7 @@ function AdminMonitorError({ message }: { message: string }) {
                 <summary className="cursor-pointer font-medium">
                     Technical details
                 </summary>
-                <p className="mt-1 break-words font-mono">{message}</p>
+                <p className="mt-1 font-mono break-words">{message}</p>
             </details>
         </div>
     );
@@ -896,6 +913,13 @@ export function AdminClient({
     const [isAddingFreeProxies, setIsAddingFreeProxies] = useState(false);
     const [isClearingFreeProxyQuarantine, setIsClearingFreeProxyQuarantine] =
         useState(false);
+    const [selectedFreeProxyRegion, setSelectedFreeProxyRegion] = useState<
+        string | null
+    >(null);
+    const [freeProxySourceDiagnostics, setFreeProxySourceDiagnostics] =
+        useState<Record<string, FreeProxyState["sourceDiagnostics"]>>({});
+    const [isLoadingFreeProxySources, setIsLoadingFreeProxySources] =
+        useState(false);
     const starterRegionSet = new Set(
         freeProxySettings.starterRegions
             .split(",")
@@ -905,8 +929,14 @@ export function AdminClient({
     const freeProxyHealthByRegion = new Map(
         freeProxyState.regions.map((region) => [region.region, region]),
     );
+    const displayedFreeProxyRegionCodes = new Set([
+        ...starterRegionSet,
+        ...freeProxyState.regions
+            .filter((region) => region.activeMonitorCount > 0)
+            .map((region) => region.region),
+    ]);
     const displayedFreeProxyRegions = REGIONS.filter((region) =>
-        starterRegionSet.has(region.code),
+        displayedFreeProxyRegionCodes.has(region.code),
     ).map((region) => {
         const health = freeProxyHealthByRegion.get(region.code);
         return health
@@ -931,13 +961,23 @@ export function AdminClient({
                   minutesSinceLastSuccess: null,
                   activeMonitorCount: 0,
                   recoveryMode: false,
+                  dueNow: 0,
+                  neverChecked: 0,
                   initializing: true,
               };
     });
-    const freeProxyTargetForRegion = (activeMonitorCount: number) =>
-        activeMonitorCount > 0
-            ? freeProxySettings.readyTarget + freeProxySettings.reserveTarget
-            : freeProxySettings.idleTarget;
+    const totalFreeProxyMonitors = displayedFreeProxyRegions.reduce(
+        (total, region) => total + region.activeMonitorCount,
+        0,
+    );
+    const selectedFreeProxyHealth = selectedFreeProxyRegion
+        ? displayedFreeProxyRegions.find(
+              (region) => region.region === selectedFreeProxyRegion,
+          )
+        : undefined;
+    const selectedFreeProxySources = selectedFreeProxyRegion
+        ? freeProxySourceDiagnostics[selectedFreeProxyRegion]
+        : undefined;
 
     const toggleStarterRegion = (regionCode: string) => {
         setFreeProxySettings((current) => {
@@ -1652,6 +1692,27 @@ export function AdminClient({
         setFreeProxySettings(normalizeFreeProxySettings(nextState.settings));
     };
 
+    const openFreeProxyRegion = async (region: string) => {
+        setSelectedFreeProxyRegion(region);
+        if (freeProxySourceDiagnostics[region]) return;
+        setIsLoadingFreeProxySources(true);
+        try {
+            const diagnostics = await getFreeProxySourceDiagnostics(region);
+            setFreeProxySourceDiagnostics((current) => ({
+                ...current,
+                [region]: diagnostics,
+            }));
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to load proxy source diagnostics",
+            );
+        } finally {
+            setIsLoadingFreeProxySources(false);
+        }
+    };
+
     const handleSaveFreeProxySettings = async () => {
         setIsSavingFreeProxySettings(true);
         const formData = new FormData();
@@ -1681,7 +1742,10 @@ export function AdminClient({
         );
         formData.set("maxLatencyMs", String(freeProxySettings.maxLatencyMs));
         formData.set("starterRegions", freeProxySettings.starterRegions);
-        formData.set("inventoryLimit", String(freeProxySettings.inventoryLimit));
+        formData.set(
+            "inventoryLimit",
+            String(freeProxySettings.inventoryLimit),
+        );
         formData.set(
             "activeCandidateLimit",
             String(freeProxySettings.activeCandidateLimit),
@@ -3726,454 +3790,576 @@ export function AdminClient({
                             ))}
                         </div>
 
-                        <div className="mt-5 grid gap-3 sm:grid-cols-2">
-                            <label className="border-border/60 flex items-start gap-3 rounded-lg border px-4 py-3">
-                                <input
-                                    type="checkbox"
-                                    checked={freeProxySettings.enabled}
-                                    onChange={(event) =>
-                                        setFreeProxySettings((prev) => ({
-                                            ...prev,
-                                            enabled: event.target.checked,
-                                        }))
-                                    }
-                                    className="mt-1"
-                                />
-                                <span>
-                                    <span className="text-sm font-medium">
-                                        Enable for users
-                                    </span>
-                                    <span className="text-muted-foreground block text-xs">
-                                        Shows Free Proxy Pool in monitor proxy
-                                        selection.
-                                    </span>
-                                </span>
-                            </label>
-                            <label className="border-border/60 flex items-start gap-3 rounded-lg border px-4 py-3">
-                                <input
-                                    type="checkbox"
-                                    checked={
-                                        freeProxySettings.autoImportEnabled
-                                    }
-                                    onChange={(event) =>
-                                        setFreeProxySettings((prev) => ({
-                                            ...prev,
-                                            autoImportEnabled:
-                                                event.target.checked,
-                                        }))
-                                    }
-                                    className="mt-1"
-                                />
-                                <span>
-                                    <span className="text-sm font-medium">
-                                        Auto import
-                                    </span>
-                                    <span className="text-muted-foreground block text-xs">
-                                        Worker refreshes the configured source
-                                        periodically.
-                                    </span>
-                                </span>
-                            </label>
+                        <div className="border-border/60 bg-muted/20 mt-4 grid gap-3 rounded-lg border p-3 sm:grid-cols-2 xl:grid-cols-4">
+                            <div>
+                                <p className="text-muted-foreground text-[10px] font-medium tracking-widest uppercase">
+                                    Maintainer
+                                </p>
+                                <p className="mt-1 text-sm font-semibold capitalize">
+                                    {freeProxyState.maintainerRuntime?.status ??
+                                        "No heartbeat"}
+                                </p>
+                                <p className="text-muted-foreground text-[11px]">
+                                    {freeProxyState.maintainerRuntime
+                                        ? `Heartbeat ${formatMetricDate(new Date(freeProxyState.maintainerRuntime.heartbeatAt))}`
+                                        : "Deploy the proxy-maintainer to publish runtime state"}
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-muted-foreground text-[10px] font-medium tracking-widest uppercase">
+                                    Effective slots
+                                </p>
+                                <p className="mt-1 text-sm font-semibold">
+                                    {freeProxyState.maintainerRuntime
+                                        ? `${freeProxyState.maintainerRuntime.concurrency} global · ${freeProxyState.maintainerRuntime.perRegionConcurrency}/region`
+                                        : "—"}
+                                </p>
+                                <p className="text-muted-foreground text-[11px]">
+                                    Actual prod runtime, including overrides
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-muted-foreground text-[10px] font-medium tracking-widest uppercase">
+                                    Last cycle
+                                </p>
+                                <p className="mt-1 text-sm font-semibold">
+                                    {freeProxyState.maintainerRuntime
+                                        ? `${freeProxyState.maintainerRuntime.checked} checked · ${freeProxyState.maintainerRuntime.passed} passed`
+                                        : "—"}
+                                </p>
+                                <p className="text-muted-foreground text-[11px]">
+                                    {freeProxyState.maintainerRuntime
+                                        ? `${Math.round(freeProxyState.maintainerRuntime.durationMs / 1000)}s · ${freeProxyState.maintainerRuntime.canceled} canceled`
+                                        : "Waiting for the first cycle"}
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-muted-foreground text-[10px] font-medium tracking-widest uppercase">
+                                    Live demand
+                                </p>
+                                <p className="mt-1 text-sm font-semibold">
+                                    {totalFreeProxyMonitors} free monitors
+                                </p>
+                                <p className="text-muted-foreground text-[11px]">
+                                    Shared by region; no cross-region failover
+                                </p>
+                            </div>
                         </div>
 
-                        <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(420px,0.9fr)]">
-                            <div className="rounded-lg border p-4">
-                                <div className="mb-4">
-                                    <p className="text-sm font-semibold">
-                                        Import Source
-                                    </p>
-                                    <p className="text-muted-foreground text-xs">
-                                        Imported proxies stay pending until
-                                        Vintrack validates them against Vinted
-                                        per starter region.
-                                    </p>
-                                </div>
-                                <div className="grid gap-3 lg:grid-cols-[220px_minmax(0,1fr)]">
-                                    <div className="space-y-2">
-                                        <Label htmlFor="free-proxy-source">
-                                            Source
-                                        </Label>
-                                        <select
-                                            id="free-proxy-source"
-                                            value={
-                                                freeProxySettings.importSource
-                                            }
-                                            onChange={(event) => {
-                                                const selected =
-                                                    FREE_PROXY_SOURCE_OPTIONS.find(
-                                                        (option) =>
-                                                            option.value ===
-                                                            event.target.value,
-                                                    );
-                                                setFreeProxySettings(
-                                                    (prev) => ({
-                                                        ...prev,
-                                                        importSource:
-                                                            event.target.value,
-                                                        importUrl:
-                                                            selected?.url ||
-                                                            prev.importUrl,
-                                                    }),
-                                                );
-                                            }}
-                                            className="border-input bg-background h-10 w-full rounded-md border px-3 text-sm"
-                                        >
-                                            {FREE_PROXY_SOURCE_OPTIONS.map(
-                                                (option) => (
-                                                    <option
-                                                        key={option.value}
-                                                        value={option.value}
-                                                    >
-                                                        {option.label}
-                                                    </option>
-                                                ),
-                                            )}
-                                        </select>
-                                    </div>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="free-proxy-import-url">
-                                            Import URL
-                                        </Label>
-                                        <Input
-                                            id="free-proxy-import-url"
-                                            value={freeProxySettings.importUrl}
+                        <details className="border-border/70 mt-4 rounded-lg border">
+                            <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center justify-between rounded-lg px-4 py-3 transition-colors [&::-webkit-details-marker]:hidden">
+                                <span>
+                                    <span className="block text-sm font-semibold">
+                                        Pool configuration
+                                    </span>
+                                    <span className="text-muted-foreground block text-xs">
+                                        Import, validation and regional target
+                                        settings
+                                    </span>
+                                </span>
+                                <Settings2 className="text-muted-foreground size-4" />
+                            </summary>
+                            <div className="border-border/60 border-t p-4">
+                                <div className="grid gap-3 sm:grid-cols-2">
+                                    <label className="border-border/60 flex items-start gap-3 rounded-lg border px-4 py-3">
+                                        <input
+                                            type="checkbox"
+                                            checked={freeProxySettings.enabled}
                                             onChange={(event) =>
                                                 setFreeProxySettings(
                                                     (prev) => ({
                                                         ...prev,
-                                                        importSource: "custom",
-                                                        importUrl:
-                                                            event.target.value,
+                                                        enabled:
+                                                            event.target
+                                                                .checked,
                                                     }),
                                                 )
                                             }
+                                            className="mt-1"
                                         />
-                                    </div>
-                                </div>
-                                <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1fr)_130px]">
-                                    <div className="space-y-2">
-                                        <div className="flex items-center justify-between gap-3">
-                                            <Label>Starter regions</Label>
-                                            <span className="text-muted-foreground text-[11px]">
-                                                {starterRegionSet.size} selected
+                                        <span>
+                                            <span className="text-sm font-medium">
+                                                Enable for users
                                             </span>
+                                            <span className="text-muted-foreground block text-xs">
+                                                Shows Free Proxy Pool in monitor
+                                                proxy selection.
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <label className="border-border/60 flex items-start gap-3 rounded-lg border px-4 py-3">
+                                        <input
+                                            type="checkbox"
+                                            checked={
+                                                freeProxySettings.autoImportEnabled
+                                            }
+                                            onChange={(event) =>
+                                                setFreeProxySettings(
+                                                    (prev) => ({
+                                                        ...prev,
+                                                        autoImportEnabled:
+                                                            event.target
+                                                                .checked,
+                                                    }),
+                                                )
+                                            }
+                                            className="mt-1"
+                                        />
+                                        <span>
+                                            <span className="text-sm font-medium">
+                                                Auto import
+                                            </span>
+                                            <span className="text-muted-foreground block text-xs">
+                                                Worker refreshes the configured
+                                                source periodically.
+                                            </span>
+                                        </span>
+                                    </label>
+                                </div>
+
+                                <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(420px,0.9fr)]">
+                                    <div className="rounded-lg border p-4">
+                                        <div className="mb-4">
+                                            <p className="text-sm font-semibold">
+                                                Import Source
+                                            </p>
+                                            <p className="text-muted-foreground text-xs">
+                                                Imported proxies stay pending
+                                                until Vintrack validates them
+                                                against Vinted per starter
+                                                region.
+                                            </p>
                                         </div>
-                                        <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-3 lg:grid-cols-4">
-                                            {REGIONS.map((region) => {
-                                                const selected =
-                                                    starterRegionSet.has(
-                                                        region.code,
-                                                    );
-                                                const health = selected
-                                                    ? freeProxyHealthByRegion.get(
-                                                          region.code,
-                                                      )
-                                                    : undefined;
-                                                return (
-                                                    <button
-                                                        key={region.code}
-                                                        type="button"
-                                                        onClick={() =>
-                                                            toggleStarterRegion(
+                                        <div className="grid gap-3 lg:grid-cols-[220px_minmax(0,1fr)]">
+                                            <div className="space-y-2">
+                                                <Label htmlFor="free-proxy-source">
+                                                    Source
+                                                </Label>
+                                                <select
+                                                    id="free-proxy-source"
+                                                    value={
+                                                        freeProxySettings.importSource
+                                                    }
+                                                    onChange={(event) => {
+                                                        const selected =
+                                                            FREE_PROXY_SOURCE_OPTIONS.find(
+                                                                (option) =>
+                                                                    option.value ===
+                                                                    event.target
+                                                                        .value,
+                                                            );
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                importSource:
+                                                                    event.target
+                                                                        .value,
+                                                                importUrl:
+                                                                    selected?.url ||
+                                                                    prev.importUrl,
+                                                            }),
+                                                        );
+                                                    }}
+                                                    className="border-input bg-background h-10 w-full rounded-md border px-3 text-sm"
+                                                >
+                                                    {FREE_PROXY_SOURCE_OPTIONS.map(
+                                                        (option) => (
+                                                            <option
+                                                                key={
+                                                                    option.value
+                                                                }
+                                                                value={
+                                                                    option.value
+                                                                }
+                                                            >
+                                                                {option.label}
+                                                            </option>
+                                                        ),
+                                                    )}
+                                                </select>
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label htmlFor="free-proxy-import-url">
+                                                    Import URL
+                                                </Label>
+                                                <Input
+                                                    id="free-proxy-import-url"
+                                                    value={
+                                                        freeProxySettings.importUrl
+                                                    }
+                                                    onChange={(event) =>
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                importSource:
+                                                                    "custom",
+                                                                importUrl:
+                                                                    event.target
+                                                                        .value,
+                                                            }),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                        </div>
+                                        <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1fr)_130px]">
+                                            <div className="space-y-2">
+                                                <div className="flex items-center justify-between gap-3">
+                                                    <Label>
+                                                        Starter regions
+                                                    </Label>
+                                                    <span className="text-muted-foreground text-[11px]">
+                                                        {starterRegionSet.size}{" "}
+                                                        selected
+                                                    </span>
+                                                </div>
+                                                <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-3 lg:grid-cols-4">
+                                                    {REGIONS.map((region) => {
+                                                        const selected =
+                                                            starterRegionSet.has(
                                                                 region.code,
-                                                            )
-                                                        }
-                                                        aria-pressed={selected}
-                                                        className={`flex min-w-0 items-center justify-between gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors ${
-                                                            selected
-                                                                ? "border-primary bg-primary/5 text-foreground"
-                                                                : "border-border/70 bg-background text-muted-foreground hover:bg-muted/50"
-                                                        }`}
-                                                    >
-                                                        <span className="flex min-w-0 items-center gap-1.5">
-                                                            <span>
-                                                                {region.flag}
-                                                            </span>
-                                                            <span className="truncate">
-                                                                {region.label}
-                                                            </span>
-                                                        </span>
-                                                        <span
-                                                            className={`h-1.5 w-1.5 shrink-0 rounded-full ${
-                                                                health?.healthy
-                                                                    ? "bg-emerald-500"
-                                                                    : health
-                                                                      ? "bg-amber-500"
-                                                                      : "bg-muted-foreground/30"
-                                                            }`}
-                                                            title={
-                                                                health?.healthy
-                                                                    ? `${health.active + health.warming} usable proxies`
-                                                                    : health
-                                                                      ? "Pool is degraded"
-                                                                      : "No pool checks yet"
-                                                            }
-                                                        />
-                                                    </button>
-                                                );
-                                            })}
+                                                            );
+                                                        const health = selected
+                                                            ? freeProxyHealthByRegion.get(
+                                                                  region.code,
+                                                              )
+                                                            : undefined;
+                                                        return (
+                                                            <button
+                                                                key={
+                                                                    region.code
+                                                                }
+                                                                type="button"
+                                                                onClick={() =>
+                                                                    toggleStarterRegion(
+                                                                        region.code,
+                                                                    )
+                                                                }
+                                                                aria-pressed={
+                                                                    selected
+                                                                }
+                                                                className={`flex min-w-0 items-center justify-between gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors ${
+                                                                    selected
+                                                                        ? "border-primary bg-primary/5 text-foreground"
+                                                                        : "border-border/70 bg-background text-muted-foreground hover:bg-muted/50"
+                                                                }`}
+                                                            >
+                                                                <span className="flex min-w-0 items-center gap-1.5">
+                                                                    <span>
+                                                                        {
+                                                                            region.flag
+                                                                        }
+                                                                    </span>
+                                                                    <span className="truncate">
+                                                                        {
+                                                                            region.label
+                                                                        }
+                                                                    </span>
+                                                                </span>
+                                                                <span
+                                                                    className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                                                                        health?.healthy
+                                                                            ? "bg-emerald-500"
+                                                                            : health
+                                                                              ? "bg-amber-500"
+                                                                              : "bg-muted-foreground/30"
+                                                                    }`}
+                                                                    title={
+                                                                        health?.healthy
+                                                                            ? `${health.active + health.warming} usable proxies`
+                                                                            : health
+                                                                              ? "Pool is degraded"
+                                                                              : "No pool checks yet"
+                                                                    }
+                                                                />
+                                                            </button>
+                                                        );
+                                                    })}
+                                                </div>
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label htmlFor="free-proxy-inventory-limit">
+                                                    Inventory limit
+                                                </Label>
+                                                <Input
+                                                    id="free-proxy-inventory-limit"
+                                                    type="number"
+                                                    min={1000}
+                                                    value={
+                                                        freeProxySettings.inventoryLimit
+                                                    }
+                                                    onChange={(event) =>
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                inventoryLimit:
+                                                                    Number(
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                    ),
+                                                            }),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
                                         </div>
                                     </div>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="free-proxy-inventory-limit">
-                                            Inventory limit
-                                        </Label>
-                                        <Input
-                                            id="free-proxy-inventory-limit"
-                                            type="number"
-                                            min={1000}
-                                            value={
-                                                freeProxySettings.inventoryLimit
-                                            }
-                                            onChange={(event) =>
-                                                setFreeProxySettings(
-                                                    (prev) => ({
-                                                        ...prev,
-                                                        inventoryLimit: Number(
-                                                            event.target.value,
-                                                        ),
-                                                    }),
-                                                )
-                                            }
-                                        />
-                                    </div>
-                                </div>
-                            </div>
 
-                            <div className="rounded-lg border p-4">
-                                <div className="mb-4">
-                                    <p className="text-sm font-semibold">
-                                        Validation Rules
-                                    </p>
-                                    <p className="text-muted-foreground text-xs">
-                                        Two successful Vinted checks are needed
-                                        before a proxy enters rotation.
-                                    </p>
+                                    <div className="rounded-lg border p-4">
+                                        <div className="mb-4">
+                                            <p className="text-sm font-semibold">
+                                                Validation Rules
+                                            </p>
+                                            <p className="text-muted-foreground text-xs">
+                                                Two successful Vinted checks are
+                                                needed before a proxy enters
+                                                rotation.
+                                            </p>
+                                        </div>
+                                        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+                                            <div className="space-y-2">
+                                                <Label htmlFor="free-proxy-failures">
+                                                    Failures
+                                                </Label>
+                                                <Input
+                                                    id="free-proxy-failures"
+                                                    type="number"
+                                                    min={1}
+                                                    value={
+                                                        freeProxySettings.failureThreshold
+                                                    }
+                                                    onChange={(event) =>
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                failureThreshold:
+                                                                    Number(
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                    ),
+                                                            }),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label htmlFor="free-proxy-quarantine">
+                                                    Cooldown
+                                                </Label>
+                                                <Input
+                                                    id="free-proxy-quarantine"
+                                                    type="number"
+                                                    min={1}
+                                                    value={
+                                                        freeProxySettings.quarantineMinutes
+                                                    }
+                                                    onChange={(event) =>
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                quarantineMinutes:
+                                                                    Number(
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                    ),
+                                                            }),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label htmlFor="free-proxy-min-active">
+                                                    Min ready
+                                                </Label>
+                                                <Input
+                                                    id="free-proxy-min-active"
+                                                    type="number"
+                                                    min={1}
+                                                    value={
+                                                        freeProxySettings.minActivePerRegion
+                                                    }
+                                                    onChange={(event) =>
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                minActivePerRegion:
+                                                                    Number(
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                    ),
+                                                            }),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label htmlFor="free-proxy-target-active">
+                                                    Target reserve
+                                                </Label>
+                                                <Input
+                                                    id="free-proxy-target-active"
+                                                    type="number"
+                                                    min={
+                                                        freeProxySettings.minActivePerRegion
+                                                    }
+                                                    value={
+                                                        freeProxySettings.targetActivePerRegion
+                                                    }
+                                                    onChange={(event) =>
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                targetActivePerRegion:
+                                                                    Number(
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                    ),
+                                                            }),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label htmlFor="free-proxy-max-latency">
+                                                    Max ms
+                                                </Label>
+                                                <Input
+                                                    id="free-proxy-max-latency"
+                                                    type="number"
+                                                    min={500}
+                                                    value={
+                                                        freeProxySettings.maxLatencyMs
+                                                    }
+                                                    onChange={(event) =>
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                maxLatencyMs:
+                                                                    Number(
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                    ),
+                                                            }),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-                                    <div className="space-y-2">
-                                        <Label htmlFor="free-proxy-failures">
-                                            Failures
-                                        </Label>
-                                        <Input
-                                            id="free-proxy-failures"
-                                            type="number"
-                                            min={1}
-                                            value={
-                                                freeProxySettings.failureThreshold
-                                            }
-                                            onChange={(event) =>
-                                                setFreeProxySettings(
-                                                    (prev) => ({
-                                                        ...prev,
-                                                        failureThreshold:
-                                                            Number(
-                                                                event.target
-                                                                    .value,
-                                                            ),
-                                                    }),
-                                                )
-                                            }
-                                        />
-                                    </div>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="free-proxy-quarantine">
-                                            Cooldown
-                                        </Label>
-                                        <Input
-                                            id="free-proxy-quarantine"
-                                            type="number"
-                                            min={1}
-                                            value={
-                                                freeProxySettings.quarantineMinutes
-                                            }
-                                            onChange={(event) =>
-                                                setFreeProxySettings(
-                                                    (prev) => ({
-                                                        ...prev,
-                                                        quarantineMinutes:
-                                                            Number(
-                                                                event.target
-                                                                    .value,
-                                                            ),
-                                                    }),
-                                                )
-                                            }
-                                        />
-                                    </div>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="free-proxy-min-active">
-                                            Min ready
-                                        </Label>
-                                        <Input
-                                            id="free-proxy-min-active"
-                                            type="number"
-                                            min={1}
-                                            value={
-                                                freeProxySettings.minActivePerRegion
-                                            }
-                                            onChange={(event) =>
-                                                setFreeProxySettings(
-                                                    (prev) => ({
-                                                        ...prev,
-                                                        minActivePerRegion:
-                                                            Number(
-                                                                event.target
-                                                                    .value,
-                                                            ),
-                                                    }),
-                                                )
-                                            }
-                                        />
-                                    </div>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="free-proxy-target-active">
-                                            Target reserve
-                                        </Label>
-                                        <Input
-                                            id="free-proxy-target-active"
-                                            type="number"
-                                            min={
-                                                freeProxySettings.minActivePerRegion
-                                            }
-                                            value={
-                                                freeProxySettings.targetActivePerRegion
-                                            }
-                                            onChange={(event) =>
-                                                setFreeProxySettings(
-                                                    (prev) => ({
-                                                        ...prev,
-                                                        targetActivePerRegion:
-                                                            Number(
-                                                                event.target
-                                                                    .value,
-                                                            ),
-                                                    }),
-                                                )
-                                            }
-                                        />
-                                    </div>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="free-proxy-max-latency">
-                                            Max ms
-                                        </Label>
-                                        <Input
-                                            id="free-proxy-max-latency"
-                                            type="number"
-                                            min={500}
-                                            value={
-                                                freeProxySettings.maxLatencyMs
-                                            }
-                                            onChange={(event) =>
-                                                setFreeProxySettings(
-                                                    (prev) => ({
-                                                        ...prev,
-                                                        maxLatencyMs: Number(
-                                                            event.target.value,
-                                                        ),
-                                                    }),
-                                                )
-                                            }
-                                        />
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
 
-                        <div className="mt-5 rounded-lg border p-4">
-                            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                <div>
-                                    <p className="text-sm font-semibold">
-                                        Regional pool scaling
-                                    </p>
-                                    <p className="text-muted-foreground text-xs">
-                                        Used regions build 50 ready clients plus
-                                        a target-validated replacement reserve.
-                                    </p>
-                                </div>
-                                <label className="flex items-center gap-2 text-xs">
-                                    <input
-                                        type="checkbox"
-                                        checked={
-                                            freeProxySettings.emergencyRecoveryEnabled
-                                        }
-                                        onChange={(event) =>
-                                            setFreeProxySettings((prev) => ({
-                                                ...prev,
-                                                emergencyRecoveryEnabled:
-                                                    event.target.checked,
-                                            }))
-                                        }
-                                    />
-                                    Emergency recovery
-                                </label>
-                            </div>
-                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-                                {[
-                                    {
-                                        id: "free-proxy-active-window",
-                                        label: "Used candidates",
-                                        value: freeProxySettings.activeCandidateLimit,
-                                        min: 1000,
-                                        key: "activeCandidateLimit" as const,
-                                    },
-                                    {
-                                        id: "free-proxy-idle-window",
-                                        label: "Idle candidates",
-                                        value: freeProxySettings.idleCandidateLimit,
-                                        min: 1000,
-                                        key: "idleCandidateLimit" as const,
-                                    },
-                                    {
-                                        id: "free-proxy-ready-target",
-                                        label: "Ready target",
-                                        value: freeProxySettings.readyTarget,
-                                        min: 1,
-                                        key: "readyTarget" as const,
-                                    },
-                                    {
-                                        id: "free-proxy-reserve-target",
-                                        label: "Reserve target",
-                                        value: freeProxySettings.reserveTarget,
-                                        min: 1,
-                                        key: "reserveTarget" as const,
-                                    },
-                                    {
-                                        id: "free-proxy-idle-target",
-                                        label: "Idle target",
-                                        value: freeProxySettings.idleTarget,
-                                        min: 1,
-                                        key: "idleTarget" as const,
-                                    },
-                                ].map((field) => (
-                                    <div key={field.id} className="space-y-2">
-                                        <Label htmlFor={field.id}>
-                                            {field.label}
-                                        </Label>
-                                        <Input
-                                            id={field.id}
-                                            type="number"
-                                            min={field.min}
-                                            value={field.value}
-                                            onChange={(event) =>
-                                                setFreeProxySettings(
-                                                    (prev) => ({
-                                                        ...prev,
-                                                        [field.key]: Number(
-                                                            event.target.value,
-                                                        ),
-                                                    }),
-                                                )
-                                            }
-                                        />
+                                <div className="mt-5 rounded-lg border p-4">
+                                    <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                        <div>
+                                            <p className="text-sm font-semibold">
+                                                Regional pool scaling
+                                            </p>
+                                            <p className="text-muted-foreground text-xs">
+                                                Used regions build 50 ready
+                                                clients plus a target-validated
+                                                replacement reserve.
+                                            </p>
+                                        </div>
+                                        <label className="flex items-center gap-2 text-xs">
+                                            <input
+                                                type="checkbox"
+                                                checked={
+                                                    freeProxySettings.emergencyRecoveryEnabled
+                                                }
+                                                onChange={(event) =>
+                                                    setFreeProxySettings(
+                                                        (prev) => ({
+                                                            ...prev,
+                                                            emergencyRecoveryEnabled:
+                                                                event.target
+                                                                    .checked,
+                                                        }),
+                                                    )
+                                                }
+                                            />
+                                            Emergency recovery
+                                        </label>
                                     </div>
-                                ))}
+                                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                                        {[
+                                            {
+                                                id: "free-proxy-active-window",
+                                                label: "Used candidates",
+                                                value: freeProxySettings.activeCandidateLimit,
+                                                min: 1000,
+                                                key: "activeCandidateLimit" as const,
+                                            },
+                                            {
+                                                id: "free-proxy-idle-window",
+                                                label: "Idle candidates",
+                                                value: freeProxySettings.idleCandidateLimit,
+                                                min: 1000,
+                                                key: "idleCandidateLimit" as const,
+                                            },
+                                            {
+                                                id: "free-proxy-ready-target",
+                                                label: "Ready target",
+                                                value: freeProxySettings.readyTarget,
+                                                min: 1,
+                                                key: "readyTarget" as const,
+                                            },
+                                            {
+                                                id: "free-proxy-reserve-target",
+                                                label: "Reserve target",
+                                                value: freeProxySettings.reserveTarget,
+                                                min: 1,
+                                                key: "reserveTarget" as const,
+                                            },
+                                            {
+                                                id: "free-proxy-idle-target",
+                                                label: "Idle target",
+                                                value: freeProxySettings.idleTarget,
+                                                min: 1,
+                                                key: "idleTarget" as const,
+                                            },
+                                        ].map((field) => (
+                                            <div
+                                                key={field.id}
+                                                className="space-y-2"
+                                            >
+                                                <Label htmlFor={field.id}>
+                                                    {field.label}
+                                                </Label>
+                                                <Input
+                                                    id={field.id}
+                                                    type="number"
+                                                    min={field.min}
+                                                    value={field.value}
+                                                    onChange={(event) =>
+                                                        setFreeProxySettings(
+                                                            (prev) => ({
+                                                                ...prev,
+                                                                [field.key]:
+                                                                    Number(
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                    ),
+                                                            }),
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
                             </div>
-                        </div>
+                        </details>
 
                         {freeProxySettings.enabled &&
                         freeProxyState.degradationReason ===
-                        "host_egress_limited" ? (
+                            "host_egress_limited" ? (
                             <div className="mt-5 flex gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
                                 <AlertTriangle className="mt-0.5 size-4 shrink-0" />
                                 <div>
@@ -4193,166 +4379,175 @@ export function AdminClient({
                             </div>
                         ) : null}
 
-                        <div className="mt-5 rounded-lg border">
+                        <div className="mt-4 rounded-lg border">
                             <div className="border-border/60 flex items-center justify-between border-b px-4 py-3">
                                 <div>
                                     <p className="text-sm font-semibold">
                                         Region Health
                                     </p>
                                     <p className="text-muted-foreground text-xs">
-                                        Used regions progress toward 50 ready +
-                                        50 reserve; idle starter regions retain
-                                        their smaller baseline.
+                                        Compact live view. Open a region for
+                                        source and failure diagnostics.
                                     </p>
                                 </div>
                             </div>
                             <div className="divide-border/60 divide-y">
                                 {displayedFreeProxyRegions.length > 0 ? (
-                                    displayedFreeProxyRegions.map((region) => (
-                                        <div
-                                            key={region.region}
-                                            className="grid gap-3 px-4 py-3 text-sm sm:grid-cols-[150px_1fr_130px_90px_120px]"
-                                        >
-                                            <div className="font-semibold">
-                                                {getRegionLabel(region.region)}
-                                            </div>
-                                            <div className="flex flex-wrap gap-2 text-xs">
-                                                <Badge
-                                                    variant={
-                                                        region.healthy
-                                                            ? "secondary"
-                                                            : "outline"
-                                                    }
-                                                    className="rounded-md uppercase"
-                                                >
-                                                    {region.initializing
-                                                        ? "Waiting"
-                                                        : region.recoveryMode
-                                                          ? "Recovery"
-                                                        : region.stalled
-                                                          ? "Stalled"
-                                                          : freeProxySettings.enabled &&
-                                                              freeProxyState.degradationReason ===
-                                                              "host_egress_limited"
-                                                            ? "Egress limited"
-                                                          : !region.healthy
-                                                            ? "Degraded"
-                                                            : region.active +
-                                                                    region.reserve +
-                                                                    region.warming <
-                                                                freeProxyTargetForRegion(
-                                                                    region.activeMonitorCount,
-                                                                )
-                                                              ? "Building"
-                                                              : "Ready"}
-                                                </Badge>
-                                                <span className="text-muted-foreground">
-                                                    {region.initializing
-                                                        ? "Waiting for the worker to assign candidates"
-                                                        : `${region.stalled ? "Maintainer overdue · " : ""}${region.active}/${region.activeMonitorCount > 0 ? freeProxySettings.readyTarget : freeProxySettings.idleTarget} ready · ${region.reserve}/${region.activeMonitorCount > 0 ? freeProxySettings.reserveTarget : freeProxySettings.idleTarget} reserve · ${region.warming} warming · ${region.candidateWindow} candidates · ${region.activeMonitorCount} monitors`}
-                                                </span>
-                                            </div>
-                                            <div className="text-muted-foreground">
-                                                {region.checkedLastHour}/h checked
-                                                <span className="block text-[11px]">
-                                                    {region.promotedLastHour}/h
-                                                    promoted
-                                                </span>
-                                            </div>
-                                            <div className="text-muted-foreground">
-                                                {region.successRate === null
-                                                    ? "n/a"
-                                                    : `${region.successRate}%`}{" "}
-                                                hit rate
-                                                {region.topErrorStage ? (
-                                                    <span className="block text-[11px]">
-                                                        Top stage:{" "}
-                                                        {region.topErrorStage}
+                                    displayedFreeProxyRegions.map((region) => {
+                                        const used =
+                                            region.activeMonitorCount > 0;
+                                        const readyTarget = used
+                                            ? freeProxySettings.readyTarget
+                                            : freeProxySettings.idleTarget;
+                                        const reserveTarget = used
+                                            ? freeProxySettings.reserveTarget
+                                            : freeProxySettings.idleTarget;
+                                        const usable =
+                                            region.active +
+                                            region.reserve +
+                                            region.warming;
+                                        const readyProgress = Math.min(
+                                            100,
+                                            (usable /
+                                                Math.max(1, readyTarget)) *
+                                                100,
+                                        );
+                                        const reserveProgress = Math.min(
+                                            100,
+                                            (region.reserve /
+                                                Math.max(1, reserveTarget)) *
+                                                100,
+                                        );
+                                        const status = region.initializing
+                                            ? "Waiting"
+                                            : region.recoveryMode
+                                              ? "Recovery"
+                                              : region.stalled
+                                                ? "Stalled"
+                                                : freeProxySettings.enabled &&
+                                                    freeProxyState.degradationReason ===
+                                                        "host_egress_limited"
+                                                  ? "Egress limited"
+                                                  : usable === 0 && used
+                                                    ? "Outage"
+                                                    : usable < readyTarget
+                                                      ? "Building"
+                                                      : used
+                                                        ? "Ready"
+                                                        : "Standby";
+                                        return (
+                                            <button
+                                                key={region.region}
+                                                type="button"
+                                                onClick={() =>
+                                                    void openFreeProxyRegion(
+                                                        region.region,
+                                                    )
+                                                }
+                                                className="hover:bg-muted/30 grid w-full gap-3 px-4 py-3 text-left text-sm transition-colors lg:grid-cols-[170px_minmax(220px,1fr)_130px_125px_130px_20px] lg:items-center"
+                                            >
+                                                <div className="flex items-center gap-2">
+                                                    <span className="font-semibold">
+                                                        {getRegionLabel(
+                                                            region.region,
+                                                        )}
                                                     </span>
-                                                ) : null}
-                                            </div>
-                                            <div className="text-muted-foreground text-xs">
-                                                {region.minutesSinceLastSuccess ===
-                                                null
-                                                    ? "No success yet"
-                                                    : `${region.minutesSinceLastSuccess}m since success`}
-                                                <span className="block">
-                                                    {region.medianLatencyMs ===
-                                                    null
-                                                        ? "n/a"
-                                                        : `${region.medianLatencyMs}ms median`}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    ))
+                                                    <Badge
+                                                        variant={
+                                                            status ===
+                                                                "Ready" ||
+                                                            status === "Standby"
+                                                                ? "secondary"
+                                                                : "outline"
+                                                        }
+                                                        className="rounded-md text-[9px] uppercase"
+                                                    >
+                                                        {status}
+                                                    </Badge>
+                                                </div>
+                                                <div className="grid gap-2 sm:grid-cols-2">
+                                                    <div>
+                                                        <div className="mb-1 flex justify-between text-[11px]">
+                                                            <span>Usable</span>
+                                                            <span className="font-medium">
+                                                                {usable}/
+                                                                {readyTarget}
+                                                            </span>
+                                                        </div>
+                                                        <div className="bg-muted h-1.5 overflow-hidden rounded-full">
+                                                            <div
+                                                                className="h-full rounded-full bg-emerald-500"
+                                                                style={{
+                                                                    width: `${readyProgress}%`,
+                                                                }}
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                    <div>
+                                                        <div className="mb-1 flex justify-between text-[11px]">
+                                                            <span>Reserve</span>
+                                                            <span className="font-medium">
+                                                                {region.reserve}
+                                                                /{reserveTarget}
+                                                            </span>
+                                                        </div>
+                                                        <div className="bg-muted h-1.5 overflow-hidden rounded-full">
+                                                            <div
+                                                                className="bg-primary h-full rounded-full"
+                                                                style={{
+                                                                    width: `${reserveProgress}%`,
+                                                                }}
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div>
+                                                    <p className="font-medium">
+                                                        {
+                                                            region.activeMonitorCount
+                                                        }{" "}
+                                                        monitors
+                                                    </p>
+                                                    <p className="text-muted-foreground text-[11px]">
+                                                        {region.candidateWindow.toLocaleString()}{" "}
+                                                        candidates
+                                                    </p>
+                                                </div>
+                                                <div>
+                                                    <p className="font-medium">
+                                                        {region.checkedLastHour}
+                                                        /h checked
+                                                    </p>
+                                                    <p className="text-muted-foreground text-[11px]">
+                                                        {
+                                                            region.promotedLastHour
+                                                        }{" "}
+                                                        had success
+                                                    </p>
+                                                </div>
+                                                <div>
+                                                    <p className="font-medium">
+                                                        {region.successRate ===
+                                                        null
+                                                            ? "n/a"
+                                                            : `${region.successRate}%`}{" "}
+                                                        pass rate
+                                                    </p>
+                                                    <p className="text-muted-foreground text-[11px]">
+                                                        {region.dueNow} due ·{" "}
+                                                        {region.neverChecked}{" "}
+                                                        unchecked
+                                                    </p>
+                                                </div>
+                                                <ChevronRight className="text-muted-foreground hidden size-4 lg:block" />
+                                            </button>
+                                        );
+                                    })
                                 ) : (
                                     <p className="text-muted-foreground px-4 py-6 text-sm">
                                         No region health checks yet. Import
                                         proxies and let the worker validate
                                         them.
-                                    </p>
-                                )}
-                            </div>
-                        </div>
-
-                        <div className="mt-5 rounded-lg border">
-                            <div className="border-border/60 border-b px-4 py-3">
-                                <p className="text-sm font-semibold">
-                                    Source and protocol yield
-                                </p>
-                                <p className="text-muted-foreground text-xs">
-                                    Latest regional outcome for rows checked in
-                                    the last 24 hours. This is pool state, not a
-                                    request-level success rate.
-                                </p>
-                            </div>
-                            <div className="divide-border/60 divide-y">
-                                {freeProxyState.sourceDiagnostics.length > 0 ? (
-                                    freeProxyState.sourceDiagnostics.map(
-                                        (diagnostic) => (
-                                            <div
-                                                key={`${diagnostic.region}:${diagnostic.source}:${diagnostic.protocol}`}
-                                                className="grid gap-2 px-4 py-3 text-xs sm:grid-cols-[170px_75px_100px_90px_100px_1fr]"
-                                            >
-                                                <span className="font-medium">
-                                                    {getRegionLabel(
-                                                        diagnostic.region,
-                                                    )}{" "}
-                                                    · {diagnostic.source}
-                                                </span>
-                                                <span className="uppercase">
-                                                    {diagnostic.protocol}
-                                                </span>
-                                                <span>
-                                                    {diagnostic.successful}/
-                                                    {diagnostic.checked} ok
-                                                </span>
-                                                <span>
-                                                    {diagnostic.successRate ===
-                                                    null
-                                                        ? "n/a"
-                                                        : `${diagnostic.successRate}%`}
-                                                </span>
-                                                <span>
-                                                    {diagnostic.active} fresh ·{" "}
-                                                    {diagnostic.reserve} reserve
-                                                    {" · "}
-                                                    {diagnostic.proxyCount}{" "}
-                                                    proxies ·{" "}
-                                                    {diagnostic.neverChecked}{" "}
-                                                    unchecked region rows
-                                                </span>
-                                                <span className="text-muted-foreground">
-                                                    {diagnostic.topErrorCode
-                                                        ? `Top error: ${diagnostic.topErrorCode}${diagnostic.topErrorStage ? ` during ${diagnostic.topErrorStage}` : ""}`
-                                                        : "No recent error class"}
-                                                </span>
-                                            </div>
-                                        ),
-                                    )
-                                ) : (
-                                    <p className="text-muted-foreground px-4 py-6 text-sm">
-                                        No source diagnostics yet.
                                     </p>
                                 )}
                             </div>
@@ -4517,6 +4712,118 @@ export function AdminClient({
                     </div>
                 </div>
             ) : null}
+
+            <Dialog
+                open={selectedFreeProxyRegion !== null}
+                onOpenChange={(open) => {
+                    if (!open) setSelectedFreeProxyRegion(null);
+                }}
+            >
+                <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-4xl">
+                    <DialogHeader>
+                        <DialogTitle>
+                            {selectedFreeProxyRegion
+                                ? getRegionLabel(selectedFreeProxyRegion)
+                                : "Proxy region"}
+                        </DialogTitle>
+                        <DialogDescription>
+                            Regional capacity, backlog and source yield. Source
+                            diagnostics are loaded only when this view opens.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {selectedFreeProxyHealth ? (
+                        <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-6">
+                            {[
+                                ["Ready", selectedFreeProxyHealth.active],
+                                ["Reserve", selectedFreeProxyHealth.reserve],
+                                [
+                                    "Monitors",
+                                    selectedFreeProxyHealth.activeMonitorCount,
+                                ],
+                                [
+                                    "Checked 1h",
+                                    selectedFreeProxyHealth.checkedLastHour,
+                                ],
+                                ["Due now", selectedFreeProxyHealth.dueNow],
+                                [
+                                    "Unchecked",
+                                    selectedFreeProxyHealth.neverChecked,
+                                ],
+                            ].map(([label, value]) => (
+                                <div
+                                    key={label}
+                                    className="border-border/60 rounded-lg border px-3 py-2"
+                                >
+                                    <p className="text-muted-foreground text-[10px] uppercase">
+                                        {label}
+                                    </p>
+                                    <p className="mt-1 text-lg font-semibold">
+                                        {value}
+                                    </p>
+                                </div>
+                            ))}
+                        </div>
+                    ) : null}
+
+                    <div className="rounded-lg border">
+                        <div className="border-border/60 border-b px-4 py-3">
+                            <p className="text-sm font-semibold">
+                                Source and protocol yield · last hour
+                            </p>
+                            <p className="text-muted-foreground text-xs">
+                                Regional validation outcomes; this is not the
+                                member request success rate.
+                            </p>
+                        </div>
+                        {isLoadingFreeProxySources &&
+                        !selectedFreeProxySources ? (
+                            <div className="text-muted-foreground flex items-center gap-2 px-4 py-8 text-sm">
+                                <Activity className="size-4 animate-pulse" />
+                                Loading regional diagnostics…
+                            </div>
+                        ) : selectedFreeProxySources &&
+                          selectedFreeProxySources.length > 0 ? (
+                            <div className="divide-border/60 divide-y">
+                                {selectedFreeProxySources.map((diagnostic) => (
+                                    <div
+                                        key={`${diagnostic.source}:${diagnostic.protocol}`}
+                                        className="grid gap-2 px-4 py-3 text-xs md:grid-cols-[minmax(140px,1fr)_70px_100px_150px_minmax(160px,1fr)] md:items-center"
+                                    >
+                                        <span className="font-medium">
+                                            {diagnostic.source}
+                                        </span>
+                                        <span className="uppercase">
+                                            {diagnostic.protocol}
+                                        </span>
+                                        <span>
+                                            {diagnostic.successful}/
+                                            {diagnostic.checked} ok ·{" "}
+                                            {diagnostic.successRate === null
+                                                ? "n/a"
+                                                : `${diagnostic.successRate}%`}
+                                        </span>
+                                        <span>
+                                            {diagnostic.active} ready ·{" "}
+                                            {diagnostic.reserve} reserve ·{" "}
+                                            {diagnostic.neverChecked} unchecked
+                                        </span>
+                                        <span className="text-muted-foreground">
+                                            {diagnostic.topErrorCode
+                                                ? `${diagnostic.topErrorCode}${diagnostic.topErrorStage ? ` · ${diagnostic.topErrorStage}` : ""}`
+                                                : "No recent error class"}
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <p className="text-muted-foreground px-4 py-8 text-sm">
+                                No source diagnostics in the last hour.
+                            </p>
+                        )}
+                    </div>
+                </DialogContent>
+            </Dialog>
 
             <Dialog open={isOpen} onOpenChange={setIsOpen}>
                 <DialogContent className="sm:max-w-md">

--- a/apps/control-center/src/lib/free-proxy-health.ts
+++ b/apps/control-center/src/lib/free-proxy-health.ts
@@ -106,29 +106,28 @@ export async function getFreeProxyPoolHealth(): Promise<FreeProxyPoolHealth> {
         starterRegionsSetting,
         degradationSetting,
         rows,
-    ] =
-        await Promise.all([
-            db.app_settings.findUnique({
-                where: { key: "free_proxy_enabled" },
-                select: { value: true },
-            }),
-            db.app_settings.findUnique({
-                where: { key: "free_proxy_min_active_per_region" },
-                select: { value: true },
-            }),
-            db.app_settings.findUnique({
-                where: { key: "free_proxy_ready_target_active_region" },
-                select: { value: true },
-            }),
-            db.app_settings.findUnique({
-                where: { key: "free_proxy_starter_regions" },
-                select: { value: true },
-            }),
-            db.app_settings.findUnique({
-                where: { key: "free_proxy_degradation_reason" },
-                select: { value: true },
-            }),
-            db.$queryRaw<FreeProxyHealthRow[]>`
+    ] = await Promise.all([
+        db.app_settings.findUnique({
+            where: { key: "free_proxy_enabled" },
+            select: { value: true },
+        }),
+        db.app_settings.findUnique({
+            where: { key: "free_proxy_min_active_per_region" },
+            select: { value: true },
+        }),
+        db.app_settings.findUnique({
+            where: { key: "free_proxy_ready_target_active_region" },
+            select: { value: true },
+        }),
+        db.app_settings.findUnique({
+            where: { key: "free_proxy_starter_regions" },
+            select: { value: true },
+        }),
+        db.app_settings.findUnique({
+            where: { key: "free_proxy_degradation_reason" },
+            select: { value: true },
+        }),
+        db.$queryRaw<FreeProxyHealthRow[]>`
             SELECT
                 region,
                 COUNT(*) FILTER (
@@ -242,7 +241,7 @@ export async function getFreeProxyPoolHealth(): Promise<FreeProxyPoolHealth> {
                 FLOOR(EXTRACT(EPOCH FROM NOW()) / 3600)::bigint
             GROUP BY region
         `,
-        ]);
+    ]);
 
     const minActivePerRegion = Number(minActiveSetting?.value ?? 25);
     const readyTarget = Number(readyTargetSetting?.value ?? 50);
@@ -328,7 +327,7 @@ export async function getFreeProxyPoolHealth(): Promise<FreeProxyPoolHealth> {
                 promotedLastHour: Number(row.promoted_last_hour),
                 recoveryMode:
                     Number(row.active_monitor_count) > 0 &&
-                    active < readyTarget,
+                    usable < readyTarget,
                 minutesSinceLastSuccess:
                     row.minutes_since_last_success === null
                         ? null

--- a/apps/worker/cmd/main.go
+++ b/apps/worker/cmd/main.go
@@ -320,6 +320,18 @@ func checkFreeProxies(ctx context.Context, store *database.Store) {
 	}
 	defer freeProxyCheckRunning.Store(false)
 
+	leaseCtx, cancelLease := context.WithTimeout(ctx, 5*time.Second)
+	releaseLease, leaseAcquired, err := store.TryAcquireFreeProxyMaintainerLeaseContext(leaseCtx)
+	cancelLease()
+	if err != nil {
+		log.Printf("free proxy maintainer lease failed: %v", err)
+		return
+	}
+	if !leaseAcquired {
+		return
+	}
+	defer releaseLease()
+
 	cycleCtx, cancelCycle := context.WithTimeout(ctx, freeProxyCheckCycleTimeout)
 	defer cancelCycle()
 
@@ -473,6 +485,17 @@ func checkFreeProxies(ctx context.Context, store *database.Store) {
 	errorCounts := make(map[string]int)
 	stageCounts := make(map[string]int)
 	startedAt := time.Now()
+	publishFreeProxyMaintainerRuntime(
+		cycleCtx,
+		store,
+		"running",
+		startedAt,
+		concurrency,
+		perRegionConcurrency,
+		perRegionBatch,
+		bootstrapBatch,
+		freeProxyWaveStats{},
+	)
 	regionCursor := 0
 	waves := 0
 
@@ -497,17 +520,18 @@ func checkFreeProxies(ctx context.Context, store *database.Store) {
 					remainingByRegion[region] = 0
 					continue
 				}
-				if regionDemand[region] > 0 {
-					usedRecoveryRegions = append(usedRecoveryRegions, region)
-				} else {
-					idleRegions = append(idleRegions, region)
-				}
-			} else {
-				if regionDemand[region] > 0 {
-					usedKeepaliveRegions = append(usedKeepaliveRegions, region)
-				} else {
-					idleRegions = append(idleRegions, region)
-				}
+			}
+
+			switch freeProxyRegionWorkClassFor(
+				bootstrapByRegion[region],
+				regionDemand[region] > 0,
+			) {
+			case freeProxyRegionWorkRecovery:
+				usedRecoveryRegions = append(usedRecoveryRegions, region)
+			case freeProxyRegionWorkKeepalive:
+				usedKeepaliveRegions = append(usedKeepaliveRegions, region)
+			case freeProxyRegionWorkIdle:
+				idleRegions = append(idleRegions, region)
 			}
 		}
 		regionCursor = (regionCursor + 1) % max(1, len(regions))
@@ -604,6 +628,17 @@ func checkFreeProxies(ctx context.Context, store *database.Store) {
 		}
 	}
 	cancelEvents()
+	publishFreeProxyMaintainerRuntime(
+		ctx,
+		store,
+		"complete",
+		startedAt,
+		concurrency,
+		perRegionConcurrency,
+		perRegionBatch,
+		bootstrapBatch,
+		total,
+	)
 
 	log.Printf(
 		"free proxy check completed: %d waves, %d checked, %d passed, %d failed, %d canceled, %d persistence failures in %s (errors %v, stages %v, protocols %v, sources %v)",
@@ -619,6 +654,43 @@ func checkFreeProxies(ctx context.Context, store *database.Store) {
 		protocolCounts,
 		sourceCounts,
 	)
+}
+
+func publishFreeProxyMaintainerRuntime(
+	ctx context.Context,
+	store *database.Store,
+	status string,
+	startedAt time.Time,
+	concurrency int,
+	perRegionConcurrency int,
+	perRegionBatch int,
+	bootstrapBatch int,
+	stats freeProxyWaveStats,
+) {
+	writeCtx, cancel := context.WithTimeout(ctx, freeProxyWriteTimeout)
+	defer cancel()
+	value := fmt.Sprintf(
+		`{"status":%q,"heartbeatAt":%q,"startedAt":%q,"concurrency":%d,"perRegionConcurrency":%d,"batchPerRegion":%d,"bootstrapBatchPerRegion":%d,"checked":%d,"passed":%d,"failed":%d,"canceled":%d,"durationMs":%d}`,
+		status,
+		time.Now().UTC().Format(time.RFC3339),
+		startedAt.UTC().Format(time.RFC3339),
+		concurrency,
+		perRegionConcurrency,
+		perRegionBatch,
+		bootstrapBatch,
+		stats.Checked,
+		stats.Passed,
+		stats.Failed,
+		stats.Canceled,
+		time.Since(startedAt).Milliseconds(),
+	)
+	if err := store.SetSettingValueContext(
+		writeCtx,
+		"free_proxy_maintainer_runtime",
+		value,
+	); err != nil && ctx.Err() == nil {
+		log.Printf("free proxy maintainer runtime publish failed: %v", err)
+	}
 }
 
 func freeProxyWaveGroupSlots(
@@ -643,6 +715,27 @@ func freeProxyWaveGroupSlots(
 		recoverySlots--
 	}
 	return recoverySlots, maintenanceSlots
+}
+
+type freeProxyRegionWorkClass uint8
+
+const (
+	freeProxyRegionWorkRecovery freeProxyRegionWorkClass = iota
+	freeProxyRegionWorkKeepalive
+	freeProxyRegionWorkIdle
+)
+
+// freeProxyRegionWorkClassFor treats every region below its configured target
+// as recovery work. Monitor demand changes the target size, but it must not
+// demote a configured region that still lacks minimum production capacity.
+func freeProxyRegionWorkClassFor(bootstrap bool, used bool) freeProxyRegionWorkClass {
+	if bootstrap {
+		return freeProxyRegionWorkRecovery
+	}
+	if used {
+		return freeProxyRegionWorkKeepalive
+	}
+	return freeProxyRegionWorkIdle
 }
 
 func freeProxyWaveClassSlots(
@@ -864,23 +957,41 @@ func validateFreeProxyWave(
 			defer cancelWrite()
 			if err != nil {
 				failed.Add(1)
-				if isWarmupTransportFailure(result.ErrorCode, result.Stage) {
+				warmupTransportFailure := isWarmupTransportFailure(
+					result.ErrorCode,
+					result.Stage,
+				)
+				if warmupTransportFailure {
 					warmupTransportFailures.Add(1)
 				}
 				countsMu.Lock()
 				errorCounts[result.ErrorCode]++
 				countsMu.Unlock()
-				if writeErr := store.RecordFreeProxyFailureStageContext(
-					writeCtx,
-					candidate.ProxyURL,
-					candidate.Region,
-					result.StatusCode,
-					err.Error(),
-					result.ErrorCode,
-					string(result.Stage),
-					failureThreshold,
-					quarantineMinutes,
-				); writeErr != nil {
+				var writeErr error
+				if candidate.Proven && warmupTransportFailure && freeProxyEgressLimited.Load() {
+					writeErr = store.RecordFreeProxyInfrastructureFailureContext(
+						writeCtx,
+						candidate.ProxyURL,
+						candidate.Region,
+						result.StatusCode,
+						err.Error(),
+						result.ErrorCode,
+						string(result.Stage),
+					)
+				} else {
+					writeErr = store.RecordFreeProxyFailureStageContext(
+						writeCtx,
+						candidate.ProxyURL,
+						candidate.Region,
+						result.StatusCode,
+						err.Error(),
+						result.ErrorCode,
+						string(result.Stage),
+						failureThreshold,
+						quarantineMinutes,
+					)
+				}
+				if writeErr != nil {
 					persistenceFailed.Add(1)
 				}
 				return

--- a/apps/worker/cmd/main_test.go
+++ b/apps/worker/cmd/main_test.go
@@ -147,6 +147,34 @@ func TestFreeProxyWaveClassSlotsPrioritizeUsedRecovery(t *testing.T) {
 	}
 }
 
+func TestFreeProxyRegionWorkClassPrioritizesEveryUnderfilledRegion(t *testing.T) {
+	tests := []struct {
+		name      string
+		bootstrap bool
+		used      bool
+		want      freeProxyRegionWorkClass
+	}{
+		{name: "used recovery", bootstrap: true, used: true, want: freeProxyRegionWorkRecovery},
+		{name: "idle recovery", bootstrap: true, used: false, want: freeProxyRegionWorkRecovery},
+		{name: "used keepalive", used: true, want: freeProxyRegionWorkKeepalive},
+		{name: "idle maintenance", want: freeProxyRegionWorkIdle},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := freeProxyRegionWorkClassFor(test.bootstrap, test.used); got != test.want {
+				t.Fatalf(
+					"freeProxyRegionWorkClassFor(%v, %v) = %d, want %d",
+					test.bootstrap,
+					test.used,
+					got,
+					test.want,
+				)
+			}
+		})
+	}
+}
+
 func TestFreeProxyAdaptiveRegionConcurrency(t *testing.T) {
 	now := time.Now()
 	if got := freeProxyAdaptiveRegionConcurrency(12, now, now.Add(time.Minute), now.Add(6*time.Minute)); got != 6 {

--- a/apps/worker/internal/database/free_proxy_store_integration_test.go
+++ b/apps/worker/internal/database/free_proxy_store_integration_test.go
@@ -13,6 +13,49 @@ import (
 	"github.com/lib/pq"
 )
 
+func TestFreeProxyMaintainerLeaseIsClusterWide(t *testing.T) {
+	databaseURL := os.Getenv("FREE_PROXY_STORE_INTEGRATION_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("FREE_PROXY_STORE_INTEGRATION_DATABASE_URL is not set")
+	}
+
+	db, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	defer db.Close()
+	store := &Store{db: db}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	releaseFirst, acquired, err := store.TryAcquireFreeProxyMaintainerLeaseContext(ctx)
+	if err != nil {
+		t.Fatalf("acquire first maintainer lease: %v", err)
+	}
+	if !acquired {
+		t.Fatal("first maintainer lease was not acquired")
+	}
+	defer releaseFirst()
+
+	_, acquired, err = store.TryAcquireFreeProxyMaintainerLeaseContext(ctx)
+	if err != nil {
+		t.Fatalf("acquire competing maintainer lease: %v", err)
+	}
+	if acquired {
+		t.Fatal("competing maintainer unexpectedly acquired cluster-wide lease")
+	}
+
+	releaseFirst()
+	releaseSecond, acquired, err := store.TryAcquireFreeProxyMaintainerLeaseContext(ctx)
+	if err != nil {
+		t.Fatalf("reacquire released maintainer lease: %v", err)
+	}
+	if !acquired {
+		t.Fatal("released maintainer lease could not be reacquired")
+	}
+	releaseSecond()
+}
+
 func TestFreeProxyStoreQueriesAgainstPostgres(t *testing.T) {
 	databaseURL := os.Getenv("FREE_PROXY_STORE_INTEGRATION_DATABASE_URL")
 	if databaseURL == "" {
@@ -133,6 +176,84 @@ func TestFreeProxyStoreQueriesAgainstPostgres(t *testing.T) {
 	if err := store.RecordFreeProxySuccessContext(ctx, proxyURL, region, 250); err != nil {
 		t.Fatalf("record success: %v", err)
 	}
+	if err := store.RecordFreeProxyInfrastructureFailureContext(
+		ctx,
+		proxyURL,
+		region,
+		0,
+		"maintainer host could not reach proxy warmup",
+		"timeout",
+		"warmup",
+	); err != nil {
+		t.Fatalf("record infrastructure failure: %v", err)
+	}
+	var infrastructureStatus string
+	var infrastructureFailureStreak int
+	var infrastructureGlobalFailures int
+	var infrastructureQuarantine sql.NullTime
+	var validatorSuccessCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			fph.status,
+			fph.failure_streak,
+			fph.success_count,
+			fp.failure_count,
+			fp.quarantined_until
+		FROM free_proxy_health fph
+		JOIN free_proxies fp ON fp.id = fph.proxy_id
+		WHERE fp.proxy_url = $1
+		  AND fph.region = $2`, proxyURL, region).Scan(
+		&infrastructureStatus,
+		&infrastructureFailureStreak,
+		&validatorSuccessCount,
+		&infrastructureGlobalFailures,
+		&infrastructureQuarantine,
+	); err != nil {
+		t.Fatalf("read infrastructure failure state: %v", err)
+	}
+	if infrastructureStatus != "active" ||
+		infrastructureFailureStreak != 0 ||
+		validatorSuccessCount != 1 ||
+		infrastructureGlobalFailures != 0 ||
+		infrastructureQuarantine.Valid {
+		t.Fatalf(
+			"infrastructure failure degraded proven proxy: status=%s regional=%d successes=%d global=%d quarantine=%v",
+			infrastructureStatus,
+			infrastructureFailureStreak,
+			validatorSuccessCount,
+			infrastructureGlobalFailures,
+			infrastructureQuarantine,
+		)
+	}
+	if err := store.TouchFreeProxyRuntimeSuccessContext(
+		ctx,
+		proxyURL,
+		region,
+		175,
+	); err != nil {
+		t.Fatalf("touch sampled runtime success: %v", err)
+	}
+	var sampledSuccessCount int
+	var sampledLatency int
+	if err := db.QueryRowContext(ctx, `
+		SELECT fph.success_count, fph.latency_ms
+		FROM free_proxy_health fph
+		JOIN free_proxies fp ON fp.id = fph.proxy_id
+		WHERE fp.proxy_url = $1
+		  AND fph.region = $2`, proxyURL, region).Scan(
+		&sampledSuccessCount,
+		&sampledLatency,
+	); err != nil {
+		t.Fatalf("read sampled runtime success: %v", err)
+	}
+	if sampledSuccessCount != validatorSuccessCount || sampledLatency != 175 {
+		t.Fatalf(
+			"sampled runtime success changed validator count/latency = %d/%d, want %d/175",
+			sampledSuccessCount,
+			sampledLatency,
+			validatorSuccessCount,
+		)
+	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO free_proxy_health (proxy_id, region, status, next_check_at, updated_at)
 		SELECT id, 'sqlother', 'pending', NOW(), NOW()
@@ -156,6 +277,9 @@ func TestFreeProxyStoreQueriesAgainstPostgres(t *testing.T) {
 			"fanout candidates = %#v, want globally successful proxy",
 			fanoutCandidates,
 		)
+	}
+	if !fanoutCandidates[0].Proven {
+		t.Fatal("globally successful candidate was not marked proven")
 	}
 	if err := store.RecordFreeProxySuccessContext(ctx, proxyURL, "sqlother", 275); err != nil {
 		t.Fatalf("record fanout success: %v", err)
@@ -519,6 +643,11 @@ func TestFreeProxyClaimUsesRegionalSourceProtocolYield(t *testing.T) {
 		`DELETE FROM free_proxies WHERE source = ANY($1)`,
 		pq.Array([]string{highSource, lowSource}),
 	)
+	defer db.ExecContext(
+		context.Background(),
+		`DELETE FROM free_proxy_source_health_stats WHERE region = $1`,
+		region,
+	)
 
 	for _, record := range []FreeProxyRecord{
 		{
@@ -650,6 +779,33 @@ func TestFreeProxyClaimUsesRegionalSourceProtocolYield(t *testing.T) {
 		region,
 	); err != nil {
 		t.Fatalf("seed regional yield history: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO free_proxy_source_health_stats (
+			region,
+			source,
+			protocol,
+			checked_count,
+			success_count,
+			failure_count,
+			last_checked_at,
+			last_success_at,
+			updated_at
+		) VALUES
+			($1, $2, 'http', 100, 50, 50, NOW(), NOW(), NOW()),
+			($1, $3, 'http', 100, 1, 99, NOW(), NOW(), NOW())
+		ON CONFLICT (region, source, protocol) DO UPDATE
+		SET checked_count = EXCLUDED.checked_count,
+			success_count = EXCLUDED.success_count,
+			failure_count = EXCLUDED.failure_count,
+			last_checked_at = EXCLUDED.last_checked_at,
+			last_success_at = EXCLUDED.last_success_at,
+			updated_at = NOW()`,
+		region,
+		highSource,
+		lowSource,
+	); err != nil {
+		t.Fatalf("seed cached regional source yield: %v", err)
 	}
 
 	candidates, err := store.ClaimFreeProxiesDueForCheck(

--- a/apps/worker/internal/database/free_proxy_store_test.go
+++ b/apps/worker/internal/database/free_proxy_store_test.go
@@ -17,9 +17,9 @@ func TestPruneUnselectedFreeProxiesSkipsEmptyKeepSet(t *testing.T) {
 func TestFreeProxyLaneQuotas(t *testing.T) {
 	bootstrap := freeProxyLaneQuotas(100, true)
 	wantBootstrap := []freeProxyLaneQuota{
-		{name: "explore", limit: 60},
-		{name: "fanout", limit: 25},
-		{name: "keepalive", limit: 15},
+		{name: "fanout", limit: 50},
+		{name: "keepalive", limit: 30},
+		{name: "explore", limit: 20},
 	}
 	if len(bootstrap) != len(wantBootstrap) {
 		t.Fatalf("bootstrap lanes = %#v, want %#v", bootstrap, wantBootstrap)

--- a/apps/worker/internal/database/store.go
+++ b/apps/worker/internal/database/store.go
@@ -47,6 +47,7 @@ const (
 	defaultMonitorRunStatsRetentionDays   = 90
 	monitorRunPruneBatchSize              = 10_000
 	monitorRunPruneMaximumBatchesPerCycle = 100
+	freeProxyMaintainerAdvisoryLockKey    = int64(8_670_505_012_026)
 )
 
 type proxyGroupBandwidthDelta struct {
@@ -65,6 +66,7 @@ type FreeProxyCandidate struct {
 	Region   string
 	Protocol string
 	Source   string
+	Proven   bool
 }
 
 type FreeProxyRecord struct {
@@ -284,6 +286,47 @@ func NewStore(connStr string, redisCache *cache.RedisCache) (*Store, error) {
 	go store.telemetryFlushLoop()
 
 	return store, nil
+}
+
+// TryAcquireFreeProxyMaintainerLease ensures that only one maintainer process
+// validates the shared inventory at a time. The advisory lock lives on a
+// dedicated PostgreSQL connection and is released automatically if the process
+// or connection disappears.
+func (s *Store) TryAcquireFreeProxyMaintainerLeaseContext(
+	ctx context.Context,
+) (release func(), acquired bool, err error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if err := conn.QueryRowContext(
+		ctx,
+		`SELECT pg_try_advisory_lock($1)`,
+		freeProxyMaintainerAdvisoryLockKey,
+	).Scan(&acquired); err != nil {
+		_ = conn.Close()
+		return nil, false, err
+	}
+	if !acquired {
+		_ = conn.Close()
+		return nil, false, nil
+	}
+
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, _ = conn.ExecContext(
+				releaseCtx,
+				`SELECT pg_advisory_unlock($1)`,
+				freeProxyMaintainerAdvisoryLockKey,
+			)
+			_ = conn.Close()
+		})
+	}
+	return release, true, nil
 }
 
 func (s *Store) BatchIsNew(monitorID int, itemIDs []int64) map[int64]bool {
@@ -1043,30 +1086,8 @@ func (s *Store) ClaimFreeProxiesDueForCheck(ctx context.Context, regions []strin
 		if claimLimit <= 0 {
 			return nil, nil
 		}
-		explore := lane == "explore"
 		rows, queryErr := tx.QueryContext(ctx, `
-			WITH group_stats AS (
-				SELECT
-					fph.region,
-					listed_source.source_name AS source,
-					fp.protocol,
-					COUNT(*)::double precision AS checked_count,
-					COUNT(*) FILTER (
-						WHERE fph.last_status_code = 200
-						  AND fph.last_error IS NULL
-					)::double precision AS successful_count
-				FROM free_proxies fp
-				JOIN free_proxy_health fph ON fph.proxy_id = fp.id
-				CROSS JOIN LATERAL unnest(
-					CASE
-						WHEN cardinality(fp.sources) > 0 THEN fp.sources
-						ELSE ARRAY[fp.source]::text[]
-					END
-				) AS listed_source(source_name)
-				WHERE fph.region = ANY($1)
-				  AND fph.last_checked_at >= NOW() - INTERVAL '6 hours'
-				GROUP BY fph.region, listed_source.source_name, fp.protocol
-			), proxy_ranked AS (
+			WITH proxy_ranked AS (
 				SELECT
 					fph.id,
 					fph.proxy_id,
@@ -1095,31 +1116,22 @@ func (s *Store) ClaimFreeProxiesDueForCheck(ctx context.Context, regions []strin
 								ELSE 5
 							END,
 							fph.last_checked_at ASC NULLS FIRST,
-							fph.score DESC,
-							MD5(fp.proxy_url || ':' || fph.region)
+					fph.score DESC,
+					MD5(fp.proxy_url || ':' || fph.region)
 					) AS proxy_rank,
-					COALESCE(source_stats.yield_score, 1.0 / 20.0) AS yield_score,
+					(COALESCE(source_stats.success_count, 0) + 1.0) /
+						(COALESCE(source_stats.checked_count, 0) + 20.0) AS source_yield_score,
+					(fph.success_count + 1.0) /
+						(fph.success_count + fph.failure_count + 20.0) AS proxy_yield_score,
 					fp.last_success_at AS global_last_success_at,
 					fph.last_checked_at,
 					fph.score
 				FROM free_proxy_health fph
 				JOIN free_proxies fp ON fp.id = fph.proxy_id
-				LEFT JOIN LATERAL (
-					SELECT MAX(
-						(group_stats.successful_count + 1.0) /
-						(group_stats.checked_count + 20.0)
-					) AS yield_score
-					FROM unnest(
-						CASE
-							WHEN cardinality(fp.sources) > 0 THEN fp.sources
-							ELSE ARRAY[fp.source]::text[]
-						END
-					) AS candidate_source(source_name)
-					JOIN group_stats
-					  ON group_stats.region = fph.region
-					 AND group_stats.source = candidate_source.source_name
-					 AND group_stats.protocol = fp.protocol
-				) source_stats ON TRUE
+				LEFT JOIN free_proxy_source_health_stats source_stats
+				  ON source_stats.region = fph.region
+				 AND source_stats.source = fp.source
+				 AND source_stats.protocol = fp.protocol
 				WHERE fph.region = ANY($1)
 				  AND fp.status <> 'disabled'
 				  AND (fp.quarantined_until IS NULL OR fp.quarantined_until <= NOW())
@@ -1131,7 +1143,7 @@ func (s *Store) ClaimFreeProxiesDueForCheck(ctx context.Context, regions []strin
 				  AND fph.candidate_window_token =
 					FLOOR(EXTRACT(EPOCH FROM NOW()) / 3600)::bigint
 				  AND (fph.next_check_at IS NULL OR fph.next_check_at <= NOW())
-				  AND CASE $5
+				  AND CASE $4
 					WHEN 'explore' THEN fph.last_checked_at IS NULL
 					WHEN 'fanout' THEN fph.success_count = 0 AND fp.success_count > 0
 					WHEN 'keepalive' THEN fph.success_count > 0
@@ -1159,7 +1171,8 @@ func (s *Store) ClaimFreeProxiesDueForCheck(ctx context.Context, regions []strin
 						PARTITION BY region
 						ORDER BY
 							priority,
-							CASE WHEN NOT $4 THEN yield_score END DESC NULLS LAST,
+							source_yield_score DESC,
+							proxy_yield_score DESC,
 							global_last_success_at DESC NULLS LAST,
 							last_checked_at ASC NULLS FIRST,
 							score DESC
@@ -1174,8 +1187,9 @@ func (s *Store) ClaimFreeProxiesDueForCheck(ctx context.Context, regions []strin
 				ORDER BY
 					ranked.priority,
 					ranked.region_rank,
-					CASE WHEN $4 THEN ranked.group_rank END,
-					CASE WHEN NOT $4 THEN ranked.yield_score END DESC NULLS LAST,
+					ranked.group_rank,
+					ranked.source_yield_score DESC,
+					ranked.proxy_yield_score DESC,
 					ranked.source_rank,
 					ranked.global_last_success_at DESC NULLS LAST,
 					ranked.last_checked_at ASC NULLS FIRST,
@@ -1195,20 +1209,25 @@ func (s *Store) ClaimFreeProxiesDueForCheck(ctx context.Context, regions []strin
 					updated_at = NOW()
 				FROM claimed_health
 				WHERE fp.id = claimed_health.proxy_id
-				RETURNING fp.id, fp.proxy_url, fp.protocol, fp.source
+				RETURNING
+					fp.id,
+					fp.proxy_url,
+					fp.protocol,
+					fp.source,
+					fp.success_count > 0 AS proven
 			)
 			SELECT
 				claimed_proxies.proxy_url,
 				claimed_health.region,
 				claimed_proxies.protocol,
-				claimed_proxies.source
+				claimed_proxies.source,
+				claimed_proxies.proven
 			FROM claimed_health
 			JOIN claimed_proxies
 			  ON claimed_proxies.id = claimed_health.proxy_id`,
 			pq.Array(regions),
 			claimLimit,
 			bootstrap,
-			explore,
 			lane,
 		)
 		if queryErr != nil {
@@ -1224,6 +1243,7 @@ func (s *Store) ClaimFreeProxiesDueForCheck(ctx context.Context, regions []strin
 				&candidate.Region,
 				&candidate.Protocol,
 				&candidate.Source,
+				&candidate.Proven,
 			); scanErr != nil {
 				return nil, scanErr
 			}
@@ -1274,16 +1294,19 @@ func freeProxyLaneQuotas(limit int, bootstrap bool) []freeProxyLaneQuota {
 		}
 	}
 
-	explore := max(1, limit*60/100)
-	fanout := max(1, limit*25/100)
-	if explore+fanout > limit {
-		fanout = max(0, limit-explore)
+	// Recovery gets the fastest known path to usable regional capacity:
+	// proxies already proven in another region first, then regional keepalive,
+	// while retaining a bounded exploration lane for new inventory.
+	fanout := max(1, limit*50/100)
+	keepalive := max(1, limit*30/100)
+	if fanout+keepalive > limit {
+		keepalive = max(0, limit-fanout)
 	}
-	keepalive := max(0, limit-explore-fanout)
+	explore := max(0, limit-fanout-keepalive)
 	return []freeProxyLaneQuota{
-		{name: "explore", limit: explore},
 		{name: "fanout", limit: fanout},
 		{name: "keepalive", limit: keepalive},
+		{name: "explore", limit: explore},
 	}
 }
 
@@ -1337,6 +1360,114 @@ func (s *Store) RecordFreeProxySuccessContext(ctx context.Context, proxyURL stri
 			check_claimed_until = NULL,
 			updated_at = NOW()
 		WHERE fp.id IN (SELECT proxy_id FROM updated_health)`, proxyURL, region, latencyMs)
+	if err != nil {
+		return err
+	}
+	return s.recordFreeProxySourceOutcomeContext(ctx, proxyURL, region, true)
+}
+
+// TouchFreeProxyRuntimeSuccessContext records sampled positive data-plane
+// evidence without incrementing validator counters. Runtime failures are kept
+// local until the maintainer independently reproduces them.
+func (s *Store) TouchFreeProxyRuntimeSuccessContext(
+	ctx context.Context,
+	proxyURL string,
+	region string,
+	latencyMs int,
+) error {
+	if proxyURL == "" {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `
+		WITH updated_health AS (
+			UPDATE free_proxy_health fph
+			SET status = 'active',
+				success_streak = GREATEST(fph.success_streak, 1),
+				failure_streak = 0,
+				latency_ms = $3,
+				last_status_code = 200,
+				last_checked_at = NOW(),
+				last_success_at = NOW(),
+				last_error = NULL,
+				last_error_code = NULL,
+				last_error_stage = NULL,
+				next_check_at = NOW() + INTERVAL '8 minutes',
+				score = GREATEST(fph.score, 50),
+				updated_at = NOW()
+			FROM free_proxies fp
+			WHERE fp.id = fph.proxy_id
+			  AND fp.proxy_url = $1
+			  AND fph.region = $2
+			RETURNING fph.proxy_id
+		)
+		UPDATE free_proxies fp
+		SET status = 'active',
+			failure_count = 0,
+			last_checked_at = NOW(),
+			last_success_at = NOW(),
+			last_error = NULL,
+			last_error_code = NULL,
+			last_error_stage = NULL,
+			quarantined_until = NULL,
+			updated_at = NOW()
+		WHERE fp.id IN (SELECT proxy_id FROM updated_health)`,
+		proxyURL,
+		region,
+		latencyMs,
+	)
+	return err
+}
+
+func (s *Store) recordFreeProxySourceOutcomeContext(
+	ctx context.Context,
+	proxyURL string,
+	region string,
+	success bool,
+) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO free_proxy_source_health_stats (
+			region,
+			source,
+			protocol,
+			checked_count,
+			success_count,
+			failure_count,
+			last_checked_at,
+			last_success_at,
+			updated_at
+		)
+		SELECT DISTINCT
+			$2,
+			LEFT(source_name, 50),
+			fp.protocol,
+			1,
+			CASE WHEN $3 THEN 1 ELSE 0 END,
+			CASE WHEN $3 THEN 0 ELSE 1 END,
+			NOW(),
+			CASE WHEN $3 THEN NOW() ELSE NULL END,
+			NOW()
+		FROM free_proxies fp
+		CROSS JOIN LATERAL unnest(
+			array_append(COALESCE(fp.sources, ARRAY[]::text[]), fp.source)
+		) AS source_name
+		WHERE fp.proxy_url = $1
+		  AND BTRIM(source_name) <> ''
+		ON CONFLICT (region, source, protocol) DO UPDATE
+		SET checked_count = free_proxy_source_health_stats.checked_count + 1,
+			success_count = free_proxy_source_health_stats.success_count
+				+ CASE WHEN $3 THEN 1 ELSE 0 END,
+			failure_count = free_proxy_source_health_stats.failure_count
+				+ CASE WHEN $3 THEN 0 ELSE 1 END,
+			last_checked_at = NOW(),
+			last_success_at = CASE
+				WHEN $3 THEN NOW()
+				ELSE free_proxy_source_health_stats.last_success_at
+			END,
+			updated_at = NOW()`,
+		proxyURL,
+		region,
+		success,
+	)
 	return err
 }
 
@@ -1600,6 +1731,62 @@ func (s *Store) RecordFreeProxyFailureStageContext(
 			  AND fp.proxy_url = $1
 			  AND fp.quarantined_until IS NOT NULL`, proxyURL)
 	}
+	if err != nil {
+		return err
+	}
+	return s.recordFreeProxySourceOutcomeContext(ctx, proxyURL, region, false)
+}
+
+// RecordFreeProxyInfrastructureFailureContext releases a health-check claim
+// without degrading a previously proven proxy. It is used only while the
+// maintainer's own egress is circuit-broken, where a warmup transport failure
+// is not reliable evidence that the proxy itself stopped working.
+func (s *Store) RecordFreeProxyInfrastructureFailureContext(
+	ctx context.Context,
+	proxyURL string,
+	region string,
+	statusCode int,
+	message string,
+	errorCode string,
+	errorStage string,
+) error {
+	if proxyURL == "" {
+		return nil
+	}
+	if len(message) > 1000 {
+		message = message[:1000]
+	}
+	_, err := s.db.ExecContext(ctx, `
+		WITH observed AS (
+			UPDATE free_proxy_health fph
+			SET last_status_code = NULLIF($3, 0),
+				last_checked_at = NOW(),
+				last_error = $4,
+				last_error_code = $5,
+				last_error_stage = NULLIF($6, ''),
+				next_check_at = NOW() + INTERVAL '10 minutes',
+				updated_at = NOW()
+			FROM free_proxies fp
+			WHERE fp.id = fph.proxy_id
+			  AND fp.proxy_url = $1
+			  AND fph.region = $2
+			RETURNING fph.proxy_id
+		)
+		UPDATE free_proxies fp
+		SET last_checked_at = NOW(),
+			last_error = $4,
+			last_error_code = $5,
+			last_error_stage = NULLIF($6, ''),
+			check_claimed_until = NULL,
+			updated_at = NOW()
+		WHERE fp.id IN (SELECT proxy_id FROM observed)`,
+		proxyURL,
+		region,
+		statusCode,
+		message,
+		errorCode,
+		errorStage,
+	)
 	return err
 }
 

--- a/apps/worker/internal/scraper/engine.go
+++ b/apps/worker/internal/scraper/engine.go
@@ -29,6 +29,7 @@ const (
 	maximumFreeProxyClientPoolSize  = 100
 	freeProxyMaxInFlightPerClient   = 2
 	defaultFreeProxyHedgeDelayMilli = 900
+	freeProxyRuntimeSuccessInterval = 5 * time.Minute
 )
 
 type Engine struct {
@@ -45,6 +46,8 @@ type Engine struct {
 	enrichersMu            sync.RWMutex
 	notificationPolicies   map[int]bool
 	notificationPoliciesMu sync.RWMutex
+	freeProxySuccessSeen   map[string]time.Time
+	freeProxySuccessSeenMu sync.Mutex
 	discoveryMode          string
 	jobsCtx                context.Context
 	jobsCancel             context.CancelFunc
@@ -80,6 +83,7 @@ func NewEngine(db *database.Store, pm *proxy.Manager, freePM *proxy.RegionPools)
 		pools:                make(map[string]*ClientPool),
 		enrichers:            make(map[string]*SellerEnricher),
 		notificationPolicies: make(map[int]bool),
+		freeProxySuccessSeen: make(map[string]time.Time),
 		discoveryMode:        discoveryMode,
 		jobsCtx:              jobsCtx,
 		jobsCancel:           jobsCancel,
@@ -529,7 +533,18 @@ func (e *Engine) MonitorTask(ctx context.Context, m model.Monitor) {
 
 		checks = nextCheck
 		gotSuccess := result.err == nil && result.status == 200
-		e.recordFreeProxyAttempts(proxySource, m.Region, result)
+		// Runtime failures only drive this process's ClientPool cooldowns and
+		// replacements. The regional maintainer is the sole authority for shared
+		// negative health transitions, while successful catalog evidence is
+		// sampled below to avoid the old per-request write storm.
+		if gotSuccess {
+			e.observeFreeProxyRuntimeSuccess(
+				proxySource,
+				m.Region,
+				result.client,
+				int(result.duration.Milliseconds()),
+			)
+		}
 
 		if !gotSuccess {
 			failureMessage := catalogFailureMessage(result)
@@ -814,78 +829,43 @@ func (e *Engine) isProxyGroupBandwidthLimitReached(m model.Monitor) bool {
 	return txBytes+rxBytes >= *m.ProxyGroupLimitBytes
 }
 
-func (e *Engine) recordFreeProxySuccess(proxySource string, client *Client, region string, latencyMs int) {
-	if proxySource != "free" || client == nil {
+// observeFreeProxyRuntimeSuccess preserves useful positive evidence without
+// restoring the old per-request write storm. Negative runtime outcomes remain
+// local to ClientPool; the maintainer must reproduce them before shared health
+// is degraded.
+func (e *Engine) observeFreeProxyRuntimeSuccess(
+	proxySource string,
+	region string,
+	client *Client,
+	latencyMs int,
+) {
+	if proxySource != "free" || client == nil || client.ProxyURL == "" {
 		return
 	}
-	e.db.RecordFreeProxySuccess(client.ProxyURL, region, latencyMs)
-}
-
-func (e *Engine) recordFreeProxyAttempts(proxySource string, region string, result catalogFetchResult) {
-	if proxySource != "free" {
+	proxyURL := client.ProxyURL
+	key := strings.ToLower(strings.TrimSpace(region)) + "\x00" + proxyURL
+	now := time.Now()
+	e.freeProxySuccessSeenMu.Lock()
+	lastSeen := e.freeProxySuccessSeen[key]
+	if !lastSeen.IsZero() && now.Sub(lastSeen) < freeProxyRuntimeSuccessInterval {
+		e.freeProxySuccessSeenMu.Unlock()
 		return
 	}
+	e.freeProxySuccessSeen[key] = now
+	e.freeProxySuccessSeenMu.Unlock()
 
-	if len(result.attempts) == 0 {
-		if result.err == nil && result.status == 200 {
-			e.recordFreeProxySuccess(proxySource, result.client, region, int(result.duration.Milliseconds()))
-		} else if result.client != nil && !errors.Is(result.err, context.Canceled) {
-			message := fmt.Sprintf("status %d", result.status)
-			if result.err != nil {
-				message = result.err.Error()
-			}
-			e.recordFreeProxyFailure(proxySource, result.client, region, result.status, message)
+	go func() {
+		ctx, cancel := context.WithTimeout(e.jobsCtx, 5*time.Second)
+		defer cancel()
+		if err := e.db.TouchFreeProxyRuntimeSuccessContext(
+			ctx,
+			proxyURL,
+			region,
+			latencyMs,
+		); err != nil {
+			log.Printf("free proxy runtime success update failed: %v", err)
 		}
-		return
-	}
-
-	for _, attempt := range result.attempts {
-		if attempt.err == nil && attempt.status == 200 {
-			e.recordFreeProxySuccess(proxySource, attempt.client, region, int(attempt.duration.Milliseconds()))
-			continue
-		}
-		if attempt.client == nil || errors.Is(attempt.err, context.Canceled) {
-			continue
-		}
-		message := fmt.Sprintf("status %d", attempt.status)
-		if attempt.err != nil {
-			message = attempt.err.Error()
-		}
-		e.recordFreeProxyFailure(proxySource, attempt.client, region, attempt.status, message)
-	}
-}
-
-func (e *Engine) recordFreeProxyFailure(proxySource string, client *Client, region string, statusCode int, message string) {
-	if proxySource != "free" || client == nil {
-		return
-	}
-	e.db.RecordFreeProxyFailureClass(
-		client.ProxyURL,
-		region,
-		statusCode,
-		message,
-		ClassifyFreeProxyFailure(errors.New(message), statusCode),
-		e.freeProxyFailureThreshold(),
-		e.freeProxyQuarantineMinutes(),
-	)
-}
-
-func (e *Engine) freeProxyFailureThreshold() int {
-	if value, ok, err := e.db.GetSettingValue("free_proxy_failure_threshold"); err == nil && ok {
-		if parsed, parseErr := strconv.Atoi(strings.TrimSpace(value)); parseErr == nil && parsed > 0 {
-			return parsed
-		}
-	}
-	return 3
-}
-
-func (e *Engine) freeProxyQuarantineMinutes() int {
-	if value, ok, err := e.db.GetSettingValue("free_proxy_quarantine_minutes"); err == nil && ok {
-		if parsed, parseErr := strconv.Atoi(strings.TrimSpace(value)); parseErr == nil && parsed > 0 {
-			return parsed
-		}
-	}
-	return 30
+	}()
 }
 
 func clientProxyLabel(client *Client, fallback string) string {

--- a/docs/worker-speed.md
+++ b/docs/worker-speed.md
@@ -47,9 +47,10 @@ Shadow discovery also runs on a healthy shared free-proxy pool so its timing can
 | `DISCORD_ALERT_WORKERS`            |          `8` | Dedicated Discord workers that cannot block dashboard/SSE or Telegram.                                             |
 | `TELEGRAM_ALERT_WORKERS`           |         `16` | Dedicated Telegram workers that cannot block dashboard/SSE or Discord.                                             |
 | `ENRICHMENT_WORKERS`               |          `8` | Concurrent persistence and seller-enrichment workers.                                                              |
-| `FREE_PROXY_HEALTH_CONCURRENCY`    |         `24` | Maximum parallel free-proxy validations in the isolated proxy-maintainer process.                                  |
-| `FREE_PROXY_HEALTH_BATCH_PER_REGION` |       `40` | Per-region cycle budget once the target reserve is available; work is claimed in bounded waves.                    |
-| `FREE_PROXY_BOOTSTRAP_BATCH_PER_REGION` |   `120` | Per-region cycle budget while the pool is below its target reserve; work is claimed in bounded waves.               |
+| `FREE_PROXY_HEALTH_CONCURRENCY`    |         `64` | Cluster-wide maximum parallel free-proxy validations in the isolated proxy-maintainer process.                     |
+| `FREE_PROXY_HEALTH_PER_REGION_CONCURRENCY` | `12` | Maximum parallel validations against one Vinted regional domain.                                                    |
+| `FREE_PROXY_HEALTH_BATCH_PER_REGION` |      `100` | Per-region cycle budget once the target reserve is available; work is claimed in bounded waves.                    |
+| `FREE_PROXY_BOOTSTRAP_BATCH_PER_REGION` |   `600` | Per-region cycle budget while the pool is below its target reserve; work is claimed in bounded waves.               |
 | `MONITOR_RUN_RETENTION_HOURS`      |         `24` | Retention for raw per-check monitor telemetry; hourly aggregates remain available separately.                      |
 | `MONITOR_RUN_STATS_RETENTION_DAYS` |         `90` | Retention for compact hourly monitor-run aggregates.                                                               |
 | `DETECTION_RETENTION_DAYS`         |         `14` | Retention for discovery/canonical comparison telemetry.                                                            |


### PR DESCRIPTION
## What changed

- prioritize every configured region below its capacity target as recovery work, even when it currently has no active monitor
- reserve most validation capacity for recovery while preserving bounded maintenance work
- check proxies already proven in another region before spending the recovery budget on raw inventory
- add cluster-wide maintainer leasing, optimized claim indexes, persisted source-yield statistics, and sampled positive runtime evidence
- align dashboard and admin state with the worker's usable-capacity definition (`active + reserve + warming`)
- expose maintainer runtime and regional/source diagnostics

## Root cause

Underfilled regions without monitor demand were classified as idle maintenance. In the observed 14-region pool, six recovering regions therefore competed evenly with eight regions that already exceeded their minimum capacity. Recovery also spent most of its lane budget exploring unchecked inventory before trying globally proven fanout candidates.

## Production impact

With the observed pool shape, recovering regions receive roughly 87.5% of each validation wave instead of sharing the idle lane with healthy regions. Existing globally proven candidates are attempted first, accelerating recovery without increasing the configured global or per-region concurrency bounds.

## Database

Adds an idempotent migration for the due-claim index and `free_proxy_source_health_stats`. Production continues to use `prisma migrate deploy`.

## Validation

- `cd apps/worker && go test ./...`
- PostgreSQL-backed `go test ./internal/database -count=1`
- `cd apps/control-center && npm run lint`
- `cd apps/control-center && npm run build`
- local aggregate verification against the 14-region pool snapshot