### PR TITLE
Fix dropped item notifications

### DIFF
--- a/apps/worker/internal/database/alert_outbox.go
+++ b/apps/worker/internal/database/alert_outbox.go
@@ -174,11 +174,25 @@ func (s *Store) ClaimAlertDeliveries(ctx context.Context, claimToken string, lim
 			  AND NOT EXISTS (
 				SELECT 1
 				FROM alert_deliveries older
+				JOIN alert_notifications older_n ON older_n.id = older.notification_id
 				WHERE older.destination_fingerprint = d.destination_fingerprint
-				  AND (older.created_at, older.id) < (d.created_at, d.id)
+				  AND older_n.expires_at > NOW()
+				  AND (
+					CASE WHEN older_n.kind = 'item_match' THEN 0 ELSE 1 END,
+					older.created_at,
+					older.id
+				  ) < (
+					CASE WHEN n.kind = 'item_match' THEN 0 ELSE 1 END,
+					d.created_at,
+					d.id
+				  )
 				  AND older.status IN ('pending', 'processing', 'retrying')
 			  )
-			ORDER BY d.next_attempt_at, d.created_at, d.id
+			ORDER BY
+				CASE WHEN n.kind = 'item_match' THEN 0 ELSE 1 END,
+				d.next_attempt_at,
+				d.created_at,
+				d.id
 			LIMIT $3
 			FOR UPDATE OF d SKIP LOCKED
 		), claimed AS (

--- a/apps/worker/internal/database/alert_outbox_integration_test.go
+++ b/apps/worker/internal/database/alert_outbox_integration_test.go
@@ -26,6 +26,7 @@ func TestAlertOutboxAgainstPostgres(t *testing.T) {
 
 	suffix := time.Now().UnixNano()
 	userID := fmt.Sprintf("alert-test-%d", suffix)
+	initialTarget := fmt.Sprintf("https://discord.test/api/webhooks/%d/initial", suffix)
 	if _, err := store.db.ExecContext(ctx, `
 		INSERT INTO "User" (id, email, role) VALUES ($1, $2, 'free')`,
 		userID, fmt.Sprintf("%s@example.test", userID)); err != nil {
@@ -37,7 +38,7 @@ func TestAlertOutboxAgainstPostgres(t *testing.T) {
 			"userId", name, query, status, region, discord_webhook,
 			webhook_active, notifications_enabled
 		) VALUES ($1, 'Alert test', 'shoes', 'active', 'de', $2, TRUE, TRUE)
-		RETURNING id`, userID, "https://discord.test/api/webhooks/id/token").Scan(&monitorID); err != nil {
+		RETURNING id`, userID, initialTarget).Scan(&monitorID); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
@@ -51,7 +52,7 @@ func TestAlertOutboxAgainstPostgres(t *testing.T) {
 		Kind: "item_match", DedupeUserItem: true,
 		IdempotencyKey: fmt.Sprintf("alert-test:%d:first", suffix),
 		ExpiresAt:      time.Now().Add(time.Hour),
-		DiscordTarget:  "https://discord.test/api/webhooks/id/token",
+		DiscordTarget:  initialTarget,
 		Payload:        model.AlertNotificationPayload{Version: 1, Kind: "item_match", MonitorName: "Alert test", Item: &model.Item{ID: 991, MonitorID: monitorID}},
 	}
 
@@ -90,7 +91,40 @@ func TestAlertOutboxAgainstPostgres(t *testing.T) {
 
 	delivery, err := store.ClaimAlertDelivery(ctx, "test-claim-1")
 	if err != nil || delivery == nil {
-		t.Fatalf("claim = %#v, %v", delivery, err)
+		var status string
+		var due, unexpired, processingBlocked, orderedBlocked bool
+		diagnosticErr := store.db.QueryRowContext(ctx, `
+			SELECT d.status, d.next_attempt_at <= NOW(), n.expires_at > NOW(),
+				EXISTS (
+					SELECT 1 FROM alert_deliveries active
+					WHERE active.destination_fingerprint = d.destination_fingerprint
+					  AND active.id <> d.id AND active.status = 'processing'
+					  AND active.lease_until > NOW()
+				),
+				EXISTS (
+					SELECT 1
+					FROM alert_deliveries older
+					JOIN alert_notifications older_n ON older_n.id = older.notification_id
+					WHERE older.destination_fingerprint = d.destination_fingerprint
+					  AND older_n.expires_at > NOW()
+					  AND (
+						CASE WHEN older_n.kind = 'item_match' THEN 0 ELSE 1 END,
+						older.created_at, older.id
+					  ) < (
+						CASE WHEN n.kind = 'item_match' THEN 0 ELSE 1 END,
+						d.created_at, d.id
+					  )
+					  AND older.status IN ('pending', 'processing', 'retrying')
+				)
+			FROM alert_deliveries d
+			JOIN alert_notifications n ON n.id = d.notification_id
+			WHERE n.user_id = $1 AND n.item_id = $2`, userID, request.ItemID).Scan(
+			&status, &due, &unexpired, &processingBlocked, &orderedBlocked,
+		)
+		t.Fatalf(
+			"claim = %#v, %v; diagnostic status=%q due=%v unexpired=%v processingBlocked=%v orderedBlocked=%v err=%v",
+			delivery, err, status, due, unexpired, processingBlocked, orderedBlocked, diagnosticErr,
+		)
 	}
 	if delivery.AttemptCount != 1 || delivery.CurrentFingerprint != delivery.DestinationFingerprint {
 		t.Fatalf("unexpected delivery: %#v", delivery)
@@ -130,8 +164,8 @@ func TestAlertOutboxAgainstPostgres(t *testing.T) {
 			t.Fatalf("enqueue %s = %v, %v", key, created, err)
 		}
 	}
-	targetA := "https://discord.test/api/webhooks/a/token"
-	targetB := "https://discord.test/api/webhooks/b/token"
+	targetA := fmt.Sprintf("https://discord.test/api/webhooks/%d/a", suffix)
+	targetB := fmt.Sprintf("https://discord.test/api/webhooks/%d/b", suffix)
 	queue("fifo-a-1", 992, targetA)
 	queue("fifo-a-2", 993, targetA)
 	queue("parallel-b", 994, targetB)
@@ -170,8 +204,8 @@ func TestAlertOutboxAgainstPostgres(t *testing.T) {
 		t.Fatalf("complete second FIFO delivery = %v, %v", completed, err)
 	}
 
-	targetC := "https://discord.test/api/webhooks/c/token"
-	targetD := "https://discord.test/api/webhooks/d/token"
+	targetC := fmt.Sprintf("https://discord.test/api/webhooks/%d/c", suffix)
+	targetD := fmt.Sprintf("https://discord.test/api/webhooks/%d/d", suffix)
 	queue("batch-c-1", 995, targetC)
 	queue("batch-c-2", 996, targetC)
 	queue("batch-d", 997, targetD)
@@ -198,6 +232,40 @@ func TestAlertOutboxAgainstPostgres(t *testing.T) {
 	}
 	if completed, err := store.CompleteAlertDelivery(ctx, *nextC); err != nil || !completed {
 		t.Fatalf("complete next C delivery = %v, %v", completed, err)
+	}
+
+	// Operational status notices must never hold a fresh item alert behind them
+	// for the same destination. FIFO still applies within item alerts and within
+	// status notices, but item_match is the latency-sensitive class.
+	targetE := fmt.Sprintf("https://discord.test/api/webhooks/%d/e", suffix)
+	statusRequest := request
+	statusRequest.ItemID = 0
+	statusRequest.Kind = "monitor_started"
+	statusRequest.DedupeUserItem = false
+	statusRequest.IdempotencyKey = fmt.Sprintf("alert-test:%d:status-before-item", suffix)
+	statusRequest.DiscordTarget = targetE
+	statusRequest.Payload = model.AlertNotificationPayload{
+		Version: 1,
+		Kind:    "monitor_started",
+	}
+	if created, err := store.EnqueueAlertNotification(ctx, statusRequest); err != nil || !created {
+		t.Fatalf("enqueue status before item = %v, %v", created, err)
+	}
+	queue("priority-item", 998, targetE)
+
+	priorityItem, err := store.ClaimAlertDelivery(ctx, "priority-item")
+	if err != nil || priorityItem == nil || priorityItem.ItemID != 998 || priorityItem.Kind != "item_match" {
+		t.Fatalf("priority item claim = %#v, %v", priorityItem, err)
+	}
+	if completed, err := store.CompleteAlertDelivery(ctx, *priorityItem); err != nil || !completed {
+		t.Fatalf("complete priority item = %v, %v", completed, err)
+	}
+	deferredStatus, err := store.ClaimAlertDelivery(ctx, "deferred-status")
+	if err != nil || deferredStatus == nil || deferredStatus.Kind != "monitor_started" {
+		t.Fatalf("deferred status claim = %#v, %v", deferredStatus, err)
+	}
+	if completed, err := store.CompleteAlertDelivery(ctx, *deferredStatus); err != nil || !completed {
+		t.Fatalf("complete deferred status = %v, %v", completed, err)
 	}
 
 	// Terminal history must not participate in the due-claim plan. This models

--- a/apps/worker/internal/database/store.go
+++ b/apps/worker/internal/database/store.go
@@ -372,6 +372,39 @@ func (s *Store) BatchIsNew(monitorID int, itemIDs []int64) map[int64]bool {
 	return result
 }
 
+// BatchExistingItemIDs reads durable item state directly from PostgreSQL. It is
+// intentionally separate from BatchIsNew: the Redis seen-set is useful for the
+// hot detection path, but it must not make every worker restart re-enrich the
+// complete initial catalog snapshot when those items are already persisted.
+func (s *Store) BatchExistingItemIDs(monitorID int, itemIDs []int64) (map[int64]bool, error) {
+	existing := make(map[int64]bool, len(itemIDs))
+	if len(itemIDs) == 0 {
+		return existing, nil
+	}
+
+	rows, err := s.db.Query(
+		`SELECT id FROM items WHERE monitor_id = $1 AND id = ANY($2)`,
+		monitorID,
+		pq.Array(itemIDs),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		existing[id] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
 func (s *Store) ClaimMonitorItem(monitorID int, itemID int64, source string) bool {
 	if monitorID <= 0 || itemID <= 0 {
 		return false

--- a/apps/worker/internal/scraper/engine.go
+++ b/apps/worker/internal/scraper/engine.go
@@ -683,19 +683,35 @@ func (e *Engine) MonitorTask(ctx context.Context, m model.Monitor) {
 				seedIDs[i] = item.ID
 				localSeen[item.ID] = now
 			}
+			existingSeedIDs, err := e.db.BatchExistingItemIDs(m.ID, seedIDs)
+			if err != nil {
+				// A failed durable-state lookup must not turn a transient database
+				// problem into thousands of foreground seller requests. The next
+				// successful monitor start can seed any genuinely missing items.
+				log.Printf("[%d] initial seed lookup failed; skipping seed enrichment: %v", m.ID, err)
+				existingSeedIDs = make(map[int64]bool, len(seedIDs))
+				for _, id := range seedIDs {
+					existingSeedIDs[id] = true
+				}
+			}
 			e.db.MarkItemsSeen(m.ID, seedIDs)
 			filteredSeeds, _ := filterAntiKeywordItems(items, m.AntiKeywords)
 			filteredSeeds, _ = filterBannedSellerItems(filteredSeeds, m.BannedSellerIDs)
+			seeded := 0
 			for _, seed := range filteredSeeds {
+				if existingSeedIDs[seed.ID] {
+					continue
+				}
 				built := e.buildItems(m, []model.VintedItem{seed})[0]
 				requireSellerMatch := requiresSellerEnrichment(m)
 				e.enqueueItem(enrichmentJob{
 					ctx: ctx, item: built, vintedItem: seed, monitor: m, proxySource: proxySource,
-					enricher: enricher, publishUpdate: false,
+					enricher: enricher, publishUpdate: false, backgroundOnly: true,
 					requireSellerMatch: requireSellerMatch,
 				}, false)
+				seeded++
 			}
-			log.Printf("[%d] initial scan seeded %d items without notifications", m.ID, len(items))
+			log.Printf("[%d] initial scan saw %d items; queued %d unpersisted seeds in background without notifications", m.ID, len(items), seeded)
 			initializedQueries[queryIndex] = true
 			e.db.RecordMonitorRun(model.MonitorRun{
 				MonitorID: m.ID, Status: "success", StatusCode: 200,

--- a/apps/worker/internal/scraper/manager.go
+++ b/apps/worker/internal/scraper/manager.go
@@ -18,6 +18,7 @@ type Manager struct {
 	discoveryRunning map[string]context.CancelFunc
 	discoveryCfg     map[string]string
 	scheduledPaused  map[int]bool
+	initialSyncDone  bool
 	mu               sync.Mutex
 }
 
@@ -50,6 +51,8 @@ func (m *Manager) Sync(ctx context.Context) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	initialWorkerSync := !m.initialSyncDone
+	m.initialSyncDone = true
 
 	activeIDs := make(map[int]bool, len(monitors))
 	returnedIDs := make(map[int]bool, len(monitors))
@@ -72,8 +75,8 @@ func (m *Manager) Sync(ctx context.Context) {
 			m.scheduledPaused[mon.ID] = true
 			continue
 		}
-		if m.scheduledPaused[mon.ID] {
-			prepareQuietHoursResume(mon)
+		if initialWorkerSync || m.scheduledPaused[mon.ID] {
+			prepareMonitorResume(mon)
 			delete(m.scheduledPaused, mon.ID)
 		}
 		activeIDs[mon.ID] = true
@@ -84,6 +87,10 @@ func (m *Manager) Sync(ctx context.Context) {
 				log.Printf("Config changed for monitor [%d], restarting...", mon.ID)
 				cancelFn()
 				delete(m.running, mon.ID)
+				// A config refresh is a continuation of an existing monitor. Treat
+				// its first catalog response as a resume so items published during
+				// the restart window are checked instead of silently seeded.
+				prepareMonitorResume(mon)
 			} else {
 				continue
 			}
@@ -133,7 +140,7 @@ func (m *Manager) Sync(ctx context.Context) {
 	}
 }
 
-func prepareQuietHoursResume(monitor *model.Monitor) {
+func prepareMonitorResume(monitor *model.Monitor) {
 	monitor.SuppressStartupNotice = true
 	monitor.ResumeAfterQuietHours = true
 }

--- a/apps/worker/internal/scraper/quiet_hours_test.go
+++ b/apps/worker/internal/scraper/quiet_hours_test.go
@@ -163,9 +163,9 @@ func TestMonitorQuietHoursInvalidConfigurationIsInactive(t *testing.T) {
 	}
 }
 
-func TestPrepareQuietHoursResumeSkipsOnlyStartupBehavior(t *testing.T) {
+func TestPrepareMonitorResumeSkipsOnlyStartupBehavior(t *testing.T) {
 	monitor := model.Monitor{}
-	prepareQuietHoursResume(&monitor)
+	prepareMonitorResume(&monitor)
 	if !monitor.SuppressStartupNotice {
 		t.Fatal("quiet-hours resume did not suppress the duplicate startup notice")
 	}

--- a/apps/worker/internal/scraper/seller_scheduler.go
+++ b/apps/worker/internal/scraper/seller_scheduler.go
@@ -10,9 +10,10 @@ import (
 // SellerEnrichmentScheduler keeps independent FIFO lanes per domain and proxy
 // source. A noisy monitor/source can therefore consume at most every Nth slot.
 type SellerEnrichmentScheduler struct {
-	input       chan enrichmentJob
-	work        chan enrichmentJob
-	oldestNanos atomic.Int64
+	input           chan enrichmentJob
+	backgroundInput chan enrichmentJob
+	work            chan enrichmentJob
+	oldestNanos     atomic.Int64
 }
 
 func NewSellerEnrichmentScheduler(capacity int, workers int) *SellerEnrichmentScheduler {
@@ -23,8 +24,11 @@ func NewSellerEnrichmentScheduler(capacity int, workers int) *SellerEnrichmentSc
 		workers = 24
 	}
 	return &SellerEnrichmentScheduler{
-		input: make(chan enrichmentJob, capacity),
-		work:  make(chan enrichmentJob, workers),
+		input:           make(chan enrichmentJob, capacity),
+		backgroundInput: make(chan enrichmentJob, capacity),
+		// Keep dispatch unbuffered so queued background work cannot be prefetched
+		// into a hidden worker-sized buffer ahead of a newly detected alert.
+		work: make(chan enrichmentJob),
 	}
 }
 
@@ -32,8 +36,12 @@ func (s *SellerEnrichmentScheduler) Submit(ctx context.Context, job enrichmentJo
 	if job.enqueuedAt.IsZero() {
 		job.enqueuedAt = time.Now()
 	}
+	input := s.input
+	if job.backgroundOnly {
+		input = s.backgroundInput
+	}
 	select {
-	case s.input <- job:
+	case input <- job:
 		return true
 	case <-ctx.Done():
 		return false
@@ -92,10 +100,10 @@ func (s *SellerEnrichmentScheduler) Run(ctx context.Context) {
 		if job.enricher != nil {
 			key = job.enricher.domain + ":" + key
 		}
-		if job.strictAttempt > 0 {
-			key = "strict-retry:" + key
-		} else if job.backgroundOnly {
+		if job.backgroundOnly {
 			key = "background:" + key
+		} else if job.strictAttempt > 0 {
+			key = "strict-retry:" + key
 		}
 		if index, ok := laneIndex[key]; ok {
 			insertAt := len(lanes[index].jobs)
@@ -131,9 +139,20 @@ func (s *SellerEnrichmentScheduler) Run(ctx context.Context) {
 	}
 
 	for {
+		// Always ingest an already-waiting foreground job before choosing the
+		// next worker assignment. Background producers use a separate bounded
+		// input, so a restart seed burst cannot sit in front of a fresh alert.
+		select {
+		case job := <-s.input:
+			add(job)
+			continue
+		default:
+		}
+
 		var next enrichmentJob
 		var output chan enrichmentJob
 		selectedLane := -1
+		selectedPriority := 3
 		now := time.Now()
 		for offset := 0; offset < len(lanes); offset++ {
 			index := (nextLane + offset) % len(lanes)
@@ -144,16 +163,25 @@ func (s *SellerEnrichmentScheduler) Run(ctx context.Context) {
 			if !candidate.readyAt.IsZero() && candidate.readyAt.After(now) {
 				continue
 			}
+			priority := enrichmentPriority(candidate)
+			if priority >= selectedPriority {
+				continue
+			}
 			next = candidate
 			selectedLane = index
+			selectedPriority = priority
 			output = s.work
-			break
+			if priority == 0 {
+				break
+			}
 		}
 
 		select {
 		case <-ctx.Done():
 			return
 		case job := <-s.input:
+			add(job)
+		case job := <-s.backgroundInput:
 			add(job)
 		case output <- next:
 			lanes[selectedLane].jobs = lanes[selectedLane].jobs[1:]
@@ -165,4 +193,14 @@ func (s *SellerEnrichmentScheduler) Run(ctx context.Context) {
 		case <-ticker.C:
 		}
 	}
+}
+
+func enrichmentPriority(job enrichmentJob) int {
+	if job.backgroundOnly {
+		return 2
+	}
+	if job.strictAttempt > 0 {
+		return 1
+	}
+	return 0
 }

--- a/apps/worker/internal/scraper/seller_scheduler_test.go
+++ b/apps/worker/internal/scraper/seller_scheduler_test.go
@@ -39,4 +39,55 @@ func TestSellerEnrichmentSchedulerFairAcrossSources(t *testing.T) {
 	}
 }
 
+func TestSellerEnrichmentSchedulerPrioritizesNewAlerts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := NewSellerEnrichmentScheduler(16, 1)
+	go scheduler.Run(ctx)
+
+	readyAt := time.Now().Add(100 * time.Millisecond)
+	jobs := []enrichmentJob{
+		{proxySource: "server", item: itemWithID(1), backgroundOnly: true, readyAt: readyAt},
+		{proxySource: "server", item: itemWithID(2), strictAttempt: 1, readyAt: readyAt},
+		{proxySource: "server", item: itemWithID(3), readyAt: readyAt},
+	}
+	for _, job := range jobs {
+		if !scheduler.Submit(ctx, job) {
+			t.Fatal("submit failed")
+		}
+	}
+
+	want := []int64{3, 2, 1}
+	for i, expected := range want {
+		select {
+		case job := <-scheduler.Work():
+			if job.item.ID != expected {
+				t.Fatalf("job %d = %d, want %d", i, job.item.ID, expected)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for scheduled work")
+		}
+	}
+}
+
+func TestSellerEnrichmentSchedulerDoesNotPrefetchBackgroundWork(t *testing.T) {
+	scheduler := NewSellerEnrichmentScheduler(16, 24)
+	if capacity := cap(scheduler.Work()); capacity != 0 {
+		t.Fatalf("work channel capacity = %d, want 0", capacity)
+	}
+}
+
+func TestSellerEnrichmentSchedulerBackgroundInputCannotBlockNewAlert(t *testing.T) {
+	scheduler := NewSellerEnrichmentScheduler(1, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if !scheduler.Submit(ctx, enrichmentJob{backgroundOnly: true, item: itemWithID(1)}) {
+		t.Fatal("background submit failed")
+	}
+	if !scheduler.Submit(ctx, enrichmentJob{item: itemWithID(2)}) {
+		t.Fatal("foreground submit was blocked by full background input")
+	}
+}
+
 func itemWithID(id int64) model.Item { return model.Item{ID: id} }


### PR DESCRIPTION
## What changed

- prioritize foreground seller enrichment over restart seed work
- avoid re-enriching already persisted initial-scan items
- treat worker and config restarts as monitor resumes so newly published items are not muted
- prioritize `item_match` deliveries over operational status notifications per destination
- ignore expired predecessor deliveries when selecting the next due alert

## Root cause

At production scale, restart seed enrichment could flood the shared scheduler. At the same time, startup/status deliveries could sit ahead of latency-sensitive item alerts for the same Discord or Telegram destination. A monitor restart also muted its first catalog response, which created a gap where detected items reached the live feed but never entered the notification outbox.

## Impact

Fresh item alerts are no longer silently lost during worker/config restarts, and operational notices cannot hold Discord or Telegram item notifications behind them. FIFO remains intact within item alerts.

## Validation

- `go test ./...`
- `go test -race ./internal/scraper ./internal/database`
- `go vet ./...`
- Postgres outbox integration test including 50,000 terminal deliveries and item-before-status priority
- `npm run lint`
- `npm run build`